### PR TITLE
feat : [BE] Meeting 엔티티 추가 및 기능 구현, UserDetailServiceImpl 수정 및 추가 구현

### DIFF
--- a/src/main/java/com/dialog/GlobalExceptionHandler.java
+++ b/src/main/java/com/dialog/GlobalExceptionHandler.java
@@ -7,19 +7,18 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-/**
- * 모든 REST API 예외를 한 곳에서 처리하는 글로벌 예외 핸들러 클래스
- * - 컨트롤러(@RestController)에서 IllegalArgumentException, IllegalStateException이 발생할 때 JSON 응답으로 처리
- */
+// 모든 REST API 예외를 한 곳에서 처리하는 글로벌 예외 핸들러 클래스
+// 컨트롤러(@RestController)에서 IllegalArgumentException, IllegalStateException이 발생할 때 JSON 응답으로 처리
+
 @RestControllerAdvice // 모든 REST 컨트롤러의 예외를 공통 처리
 public class GlobalExceptionHandler {
 
-    /**
-     * IllegalArgumentException, IllegalStateException 예외 발생 시
-     * - 서버에서 예외 발생 시 여기서 잡아서 클라이언트에 JSON 형태의 에러 응답 반환
-     * @param ex 런타임 예외 객체
-     * @return { "message": 예외메시지 } 형태의 JSON과 400(Bad Request) 코드 반환
-     */
+ 
+    // IllegalArgumentException, IllegalStateException 예외 발생 시
+    //  - 서버에서 예외 발생 시 여기서 잡아서 클라이언트에 JSON 형태의 에러 응답 반환
+    //  @param ex 런타임 예외 객체
+    //  @return { "message": 예외메시지 } 형태의 JSON과 400(Bad Request) 코드 반환
+     
     @ExceptionHandler({IllegalArgumentException.class, IllegalStateException.class})
     public ResponseEntity<?> handleCustomException(RuntimeException ex) {
         // 1. 에러 메시지만 담는 Map 객체 생성

--- a/src/main/java/com/dialog/keyword/domain/Keyword.java
+++ b/src/main/java/com/dialog/keyword/domain/Keyword.java
@@ -1,0 +1,47 @@
+package com.dialog.keyword.domain;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.annotations.CreationTimestamp;
+
+import com.dialog.meeting.domain.Meeting;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
+@Entity
+@Table(name = "keyword")
+@Getter
+@Setter 
+@NoArgsConstructor
+@AllArgsConstructor 
+@Builder
+public class Keyword {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 100, unique = true)
+    private String name;
+
+    @Column(name = "created_at")
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    // 다대다 역방향
+    @ManyToMany(mappedBy = "keywords")
+    private List<Meeting> meetings = new ArrayList<>();
+}

--- a/src/main/java/com/dialog/keyword/repository/KeywordRepository.java
+++ b/src/main/java/com/dialog/keyword/repository/KeywordRepository.java
@@ -1,0 +1,16 @@
+package com.dialog.keyword.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+import com.dialog.keyword.domain.Keyword;
+import com.dialog.user.domain.MeetUser;
+
+public interface KeywordRepository extends JpaRepository<Keyword, Long> {
+    List<Keyword> findByMeetingsId(Long meetingId);
+
+    Optional<Keyword> findByName(String name);
+}

--- a/src/main/java/com/dialog/meeting/domain/Meeting.java
+++ b/src/main/java/com/dialog/meeting/domain/Meeting.java
@@ -1,10 +1,14 @@
 package com.dialog.meeting.domain;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
+import com.dialog.keyword.domain.Keyword;
+import com.dialog.participant.domain.Participant;
 import com.dialog.user.domain.MeetUser;
 
 import jakarta.persistence.Column;
@@ -16,8 +20,11 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
 import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -25,61 +32,74 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-/**
- * 회의(Meeting) 정보를 담는 엔티티 (DB 테이블과 1:1 매핑)
- */
 @Entity
 @Table(name = "meeting")
-@Getter // Getter만 열어두어 데이터 조회만 허용
-@NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA가 사용하는 기본 생성자 (외부 접근 금지)
-@AllArgsConstructor // 빌더가 모든 필드를 초기화하는 생성자를 사용하도록 함
-@Builder(toBuilder = true) // 빌더 패턴 활성화
+@Getter 
+@NoArgsConstructor(access = AccessLevel.PROTECTED) 
+@AllArgsConstructor 
+@Builder(toBuilder = true) 
 public class Meeting {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id; // 회의 고유 식별자 (PK)
-
+	
 	@Column(nullable = false, length = 255)
 	private String title; // 회의 제목
-
+	
 	@Lob // 긴 텍스트 (TEXT 또는 LONGTEXT)
 	private String description; // 회의 설명
-
+	
 	@Column(name = "scheduled_at", nullable = false)
 	private LocalDateTime scheduledAt; // 예약된 회의 시작 시간
-
+	
 	@Column(name = "started_at")
 	private LocalDateTime startedAt; // 실제 회의 시작 시간
-
+	
 	@Column(name = "ended_at")
 	private LocalDateTime endedAt; // 실제 회의 종료 시간
-
+	
 	@Enumerated(EnumType.STRING) // Enum 이름을 문자열로 DB에 저장
 	@Column(nullable = false)
-    @Builder.Default // 빌더로 객체 생성 시, 값을 안 주면 이 기본값이 설정됨
+	    @Builder.Default // 빌더로 객체 생성 시, 값을 안 주면 이 기본값이 설정됨
 	private Status status = Status.SCHEDULED; // 회의 상태
-
+	
 	@ManyToOne(fetch = FetchType.LAZY) // N:1 연관관계 (지연 로딩)
 	@JoinColumn(name = "host_user_id", nullable = false) // 외래키(FK)
 	private MeetUser hostUser; // 회의 주최자 (MeetUser 엔티티 참조)
-
+	
 	@Lob
 	private String summary; // AI 회의 요약본
-
+	
 	@CreationTimestamp // 엔티티 생성 시 자동으로 현재 시간 저장
 	@Column(name = "created_at", nullable = false, updatable = false)
 	private LocalDateTime createdAt; // 레코드 생성 일시
-
+	
 	@UpdateTimestamp // 엔티티 수정 시 자동으로 현재 시간 저장
 	@Column(name = "updated_at", nullable = false)
 	private LocalDateTime updatedAt; // 레코드 마지막 수정 일시
+	
+	// --------------추가------------------------------
+	// 회의 참석자, 키워드 부분
+	
+	@OneToMany(mappedBy = "meeting", fetch = FetchType.LAZY)
+	private List<Participant> participants;
+	
+    // 키워드 연관관계 (다대다)
+	@Builder.Default
+    @ManyToMany
+    @JoinTable(
+        name = "MeetingKeyword",
+        joinColumns = @JoinColumn(name = "meeting_id"),
+        inverseJoinColumns = @JoinColumn(name = "keyword_id")
+    )
+    private List<Keyword> keywords = new ArrayList<>();
 
     // --- 비즈니스 로직 (Setter 대신 사용) ---
 
-    /**
-     * 회의 제목과 설명을 수정합니다. (Setter 대용)
-     */
+    
+    //  회의 제목과 설명을 수정합니다. (Setter 대용)
+     
     public void updateInfo(String title, String description) {
         if (title != null) {
             this.title = title;
@@ -89,25 +109,25 @@ public class Meeting {
         }
     }
 
-    /**
-     * 회의 상태를 '녹음 중(RECORDING)'으로 변경하고 시작 시간을 기록합니다.
-     */
+    
+    //  회의 상태를 '녹음 중(RECORDING)'으로 변경하고 시작 시간을 기록합니다.
+     
     public void startRecording() {
         this.status = Status.RECORDING;
         this.startedAt = LocalDateTime.now(); 
     }
 
-    /**
-     * 회의 상태를 '완료(COMPLETED)'로 변경하고 종료 시간을 기록합니다.
-     */
+    
+    //  회의 상태를 '완료(COMPLETED)'로 변경하고 종료 시간을 기록합니다.
+    
     public void complete() {
         this.status = Status.COMPLETED;
         this.endedAt = LocalDateTime.now(); 
     }
 
-    /**
-     * AI 요약본을 업데이트합니다.
-     */
+
+    // AI 요약본을 업데이트합니다.
+ 
     public void updateSummary(String newSummary) {
         this.summary = newSummary;
     }

--- a/src/main/java/com/dialog/meeting/domain/MeetingCreateRequestDto.java
+++ b/src/main/java/com/dialog/meeting/domain/MeetingCreateRequestDto.java
@@ -4,18 +4,28 @@ import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
-/**
- * (Request) 회의 생성 요청 시 클라이언트가 보낼 데이터를 담는 클래스
- */
 @Getter
+@Setter
 @NoArgsConstructor
 public class MeetingCreateRequestDto {
 
-    private String title;           // 'meeting-title' 인풋
-    private LocalDateTime scheduledAt; // 'meeting-date' 인풋
-    private String description;     // 'meeting-description' 텍스트 영역
-    
-    private List<String> participantNames; // 'participant-name' 인풋 목록
-    private List<String> keywords;         // 'keyword-input' 인풋 목록
+    @NotBlank(message = "회의 제목은 반드시 입력해야 합니다.")
+    private String title;
+
+    @NotBlank(message = "회의 예약 시간은 반드시 입력해야 합니다.")
+    private String scheduledAt;
+
+    @NotBlank(message = "회의 설명은 반드시 입력해야 합니다.")
+    private String description;
+
+    @NotNull(message = "참가자 목록은 반드시 입력해야 합니다.")
+    @Size(min = 1, message = "참가자는 한 명 이상 입력해야 합니다.")
+    private List<String> participants;
+
+    private List<String> keywords;
 }

--- a/src/main/java/com/dialog/meeting/domain/MeetingCreateResponseDto.java
+++ b/src/main/java/com/dialog/meeting/domain/MeetingCreateResponseDto.java
@@ -1,27 +1,34 @@
 package com.dialog.meeting.domain;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * (Response) 회의 생성 응답 시 서버가 보낼 데이터를 담는 클래스
  */
 @Getter
+@Setter
+@NoArgsConstructor
 public class MeetingCreateResponseDto {
 
     private Long meetingId;   // 새로 생성된 회의 ID
     private String title;     // 생성된 회의 제목
     private Status status;    // 현재 상태 (예: SCHEDULED)
     private LocalDateTime scheduledAt; // 예약 시간
+    private List<String> participants; // 참가자 이름 리스트
+    private List<String> keywords;     // 키워드 리스트
 
-    /**
-     * Entity 객체를 DTO로 변환하는 생성자
-     */
-    public MeetingCreateResponseDto(Meeting meeting) {
+    // Entity 객체를 DTO로 변환하는 생성자
+    public MeetingCreateResponseDto(Meeting meeting, List<String> participants, List<String> keywords) {
         this.meetingId = meeting.getId();
         this.title = meeting.getTitle();
         this.status = meeting.getStatus();
         this.scheduledAt = meeting.getScheduledAt();
+        this.participants = participants;
+        this.keywords = keywords;
     }
 }

--- a/src/main/java/com/dialog/meeting/service/MeetingService.java
+++ b/src/main/java/com/dialog/meeting/service/MeetingService.java
@@ -1,21 +1,28 @@
 package com.dialog.meeting.service;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.dialog.keyword.domain.Keyword;
+import com.dialog.keyword.repository.KeywordRepository;
 import com.dialog.meeting.domain.Meeting;
 // 👈 [수정] DTO 패키지 경로로 변경
 import com.dialog.meeting.domain.MeetingCreateRequestDto;
 import com.dialog.meeting.domain.MeetingCreateResponseDto;
 import com.dialog.meeting.repository.MeetingRepository;
+import com.dialog.participant.domain.Participant;
+import com.dialog.participant.repository.ParticipantRepository;
 import com.dialog.user.domain.MeetUser;
 import com.dialog.user.repository.MeetUserRepository;
 
 import lombok.RequiredArgsConstructor;
 
-/**
- * 회의(Meeting) 관련 비즈니스 로직을 처리하는 서비스 클래스
- */
+
 @Service
 @RequiredArgsConstructor // final 레포지토리 필드 생성자 주입
 @Transactional(readOnly = true) // (기본) 읽기 전용 트랜잭션 (조회 성능 최적화)
@@ -23,36 +30,97 @@ public class MeetingService {
 
     private final MeetingRepository meetingRepository;
     private final MeetUserRepository meetUserRepository; 
+    private final ParticipantRepository participantRepository;
+    private final KeywordRepository keywordRepository;
 
-    /**
-     * 새로운 회의를 생성합니다. (쓰기 작업)
-     */
-    @Transactional // 이 메서드는 DB에 쓰기 작업을 하므로 별도 @Transactional 명시
-    public MeetingCreateResponseDto createMeeting(MeetingCreateRequestDto requestDto, Long hostUserId) {
+    // 회의 생성
+    @Transactional 
+    public MeetingCreateResponseDto createMeeting(MeetingCreateRequestDto requestDto, Long hostUserId) throws IllegalAccessException {
 
         // 1. 주최자(User) 엔티티 조회
         MeetUser hostUser = meetUserRepository.findById(hostUserId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다.")); // .get() 대신 예외 처리
 
-        // 2. 👈 [수정] 빌더 패턴을 사용해 DTO를 Meeting 엔티티로 변환
+        // 2. 빌더 패턴을 사용해 DTO를 Meeting 엔티티로 변환
+        LocalDateTime scheduledAt;
+        try {
+            scheduledAt = LocalDateTime.parse(requestDto.getScheduledAt()); // 기본 파서: yyyy-MM-ddTHH:mm:ss에 맞게
+        } catch (DateTimeParseException e) {
+            throw new IllegalAccessException("잘못된 날짜 형식입니다. yyyy-MM-dd'T'HH:mm:ss 형식으로 보내야 합니다.");
+        }
         Meeting newMeeting = Meeting.builder()
                 .title(requestDto.getTitle())
                 .description(requestDto.getDescription())
-                .scheduledAt(requestDto.getScheduledAt())
+                .scheduledAt(scheduledAt)
                 .hostUser(hostUser)
-                // .status(Status.SCHEDULED) // 엔티티의 @Builder.Default로 자동 설정됨
                 .build();
 
-        // 3. (저장) 레포지토리를 사용해 엔티티를 DB에 저장 (영속화)
+        // 3. 엔티티를 DB에 저장
         Meeting savedMeeting = meetingRepository.save(newMeeting);
 
-        // 4. (부가 로직) DTO로 받은 participantNames와 keywords를
-        //    'Participant' 엔티티와 'Keyword' 엔티티로 변환하여 저장
-        //    (TODO: 관련 서비스 로직 추가 위치)
+        // 4. 참석자 등록
+        List<Participant> participantEntities = new ArrayList<>();
+        for (String speakerId : requestDto.getParticipants()) {
+            Participant participant = Participant.builder()
+                .meeting(savedMeeting)
+                .speakerId(speakerId)
+                .name(speakerId) // 이름이 필요하면 speakerId->이름 변환 로직 구현
+                .build();
+            participantEntities.add(participant);
+        }
+        participantRepository.saveAll(participantEntities);
+        
+        // 5. 키워드 등록 및 ManyToMany 연관관계 설정
+        // 기존 키워드 재사용(중복사용방지) , 없으면 새로 생성하여 저장
+        List<Keyword> keywordEntities = new ArrayList<>();
+        if (requestDto.getKeywords() != null) {
+            for (String keywordName : requestDto.getKeywords()) {
+            	// keywordRepository.findByName(keywordName) -> DB 에 해당 키워드가 있는지 먼저 조회
+                Keyword keyword = keywordRepository.findByName(keywordName)
+                		// 없으면 새로 생성해서 DB 에 저장후 반환
+                    .orElseGet(() -> keywordRepository.save(Keyword.builder().name(keywordName).build()));
+                keywordEntities.add(keyword);
+            }
+            savedMeeting.getKeywords().addAll(keywordEntities);
+            meetingRepository.save(savedMeeting);
+        }
 
-        // 5. (변환) 저장된 엔티티를 Response DTO로 변환하여 컨트롤러에 반환
-        return new MeetingCreateResponseDto(savedMeeting);
+        // 6. 응답 반환 세팅 (이름/키워드 스트링값만 추출)
+        List<String> participantIds = new ArrayList<>();
+        for (Participant participant : participantEntities) {
+            participantIds.add(participant.getSpeakerId());
+        }
+
+        List<String> keywordNames = new ArrayList<>();
+        for (Keyword k : keywordEntities) {
+            keywordNames.add(k.getName());
+        }
+
+        return new MeetingCreateResponseDto(savedMeeting, participantIds, keywordNames);
+        
+    }
+	public MeetingCreateResponseDto findById(Long meetingId) {
+        // 1. 회의 조회
+        Meeting meeting = meetingRepository.findById(meetingId)
+            .orElseThrow(() -> new IllegalArgumentException("회의를 찾을 수 없습니다."));
+        
+        // 2. 해당 회의 id 값을 통해 참가자 조회
+        List<Participant> participantEntities = participantRepository.findByMeetingId(meetingId);
+        // 3. 참가자의 이름만 뽑아서 List 로 추출
+        List<String> participants = new ArrayList<>();
+        for (Participant p : participantEntities) {
+            participants.add(p.getSpeakerId());
+        }
+
+        // 4. 해당 회의 id 값을 통해 하이라이트 조회
+        List<Keyword> highlightEntities = keywordRepository.findByMeetingsId(meetingId);
+        // 5. 하이라이트의 키워드만 뽑아서 List 로 추출
+        List<String> keywords = new ArrayList<>();
+        for (Keyword h : highlightEntities) {
+            keywords.add(h.getName());
+        }
+        // 6. List 로 추출한 키워드, 참가자 이름을 DTO로 반환
+        return new MeetingCreateResponseDto(meeting, participants, keywords);
     }
 
-    // TODO: 회의 조회, 수정, 삭제 등의 다른 서비스 메소드들...
 }

--- a/src/main/java/com/dialog/participant/domain/Participant.java
+++ b/src/main/java/com/dialog/participant/domain/Participant.java
@@ -1,0 +1,55 @@
+package com.dialog.participant.domain;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.CreationTimestamp;
+
+import com.dialog.meeting.domain.Meeting;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
+
+@Entity
+@Getter 
+@Setter 
+@NoArgsConstructor
+@AllArgsConstructor 
+@Builder
+@Table(name = "participant",
+		uniqueConstraints = @UniqueConstraint(name = "uq_meeting_speaker", columnNames = {"meeting_id", "speaker_id"})
+)
+public class Participant {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "meeting_id", nullable = false)
+    private Meeting meeting;
+
+    @Column(name = "speaker_id", length = 50, nullable = false)
+    private String speakerId;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "created_at")
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/dialog/participant/repository/ParticipantRepository.java
+++ b/src/main/java/com/dialog/participant/repository/ParticipantRepository.java
@@ -1,0 +1,10 @@
+package com.dialog.participant.repository;
+
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.dialog.participant.domain.Participant;
+import java.util.List;
+
+public interface ParticipantRepository extends JpaRepository<Participant, Long> {
+    List<Participant> findByMeetingId(Long meetingId);
+}

--- a/src/main/java/com/dialog/security/SecurityConfigJWT.java
+++ b/src/main/java/com/dialog/security/SecurityConfigJWT.java
@@ -36,7 +36,7 @@ public class SecurityConfigJWT {
         return http
     		.cors(withDefaults()) // CORS 허용	
             // 1. CSRF 설정: 특정 경로(h2-console, /api/**)는 CSRF 보호 안함
-            .csrf(csrf -> csrf.ignoringRequestMatchers("/h2-console/**", "/api/**"))
+            .csrf(csrf -> csrf.ignoringRequestMatchers("/api/**"))
             
             // 2. HTTP Basic 인증 비활성화
             .httpBasic(httpBasic -> httpBasic.disable())

--- a/src/main/java/com/dialog/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/dialog/security/jwt/JwtTokenProvider.java
@@ -14,7 +14,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
-
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 
 import com.dialog.security.oauth2.CustomOAuth2User;
@@ -38,14 +38,17 @@ public class JwtTokenProvider {
     // JWT 암호화키 (application.yml에서 주입됨)
     private final SecretKey key;
     private final long validityInMilliseconds;
-
+    private final UserDetailsService userDetailsService;
+    
     // 생성자에서 시크릿키, 만료시간 설정해 멤버변수에 저장
     public JwtTokenProvider(@Value("${jwt.secret:DefaultSecretKeyDefaultSecretKeyDefaultSecretKeyDefaultSecretKey}") String secretKey,
-                            @Value("${jwt.expiration:3600000}") long validityInMilliseconds) {
+                            @Value("${jwt.expiration:3600000}") long validityInMilliseconds,
+                            UserDetailsService userDetailsService) {
         // 시크릿키 base64 → 바이트 배열 → HMAC-SHA용 SecretKey 객체 생성
         byte[] keyBytes = Decoders.BASE64.decode(secretKey);
         this.key = Keys.hmacShaKeyFor(keyBytes);
         this.validityInMilliseconds = validityInMilliseconds;
+        this.userDetailsService = userDetailsService;
     }
 
     // JWT 토큰 발급 메서드: 인증객체 받으면 토큰 생성하여 반환
@@ -63,19 +66,16 @@ public class JwtTokenProvider {
         String email = "";
 
         if (principal instanceof CustomOAuth2User) {
-        	// 소셜 사용자라면 name/email을 각각 추출
-            log.info("principal.getname() = {}", ((CustomOAuth2User) principal).getname());
-            log.info("principal.getEmail() = {}", ((CustomOAuth2User) principal).getEmail());
             name = ((CustomOAuth2User) principal).getname();
             email = ((CustomOAuth2User) principal).getEmail();
-            log.info("principal class: " + principal.getClass().getName());
         } else if (principal instanceof UserDetails) {
-        	// 일반 로그인: username이 실제 email이어야 인증 흐름이 안전!
             name = ((UserDetails) principal).getUsername();
-            email = "";
+            email = ((UserDetails) principal).getUsername();
         } else if (principal instanceof String) {
             name = (String) principal;
+            email = "";  // 필요시 처리
         }
+        
 
         return Jwts.builder()
                 .subject(email)           		// subject(기본 피식별자)는 email로 지정 (username이 email이면 OK)
@@ -85,6 +85,7 @@ public class JwtTokenProvider {
                 .signWith(key)            		// 서명에 SecretKey 사용
                 .expiration(validity)     		// 만료시간 지정
                 .compact();
+        
     }
     // JWT 토큰을 파싱해서 인증객체(Authentication)로 복원하는 메서드
     public Authentication getAuthentication(String token) {
@@ -98,22 +99,28 @@ public class JwtTokenProvider {
                     .getPayload();
             log.info("토큰에서 추출된 subject: " + claims.getSubject());
             log.info("토큰에서 추출된 auth: " + claims.get("auth"));
+
             Collection<? extends GrantedAuthority> authorities;
             Object authClaim = claims.get("auth");
             if (authClaim != null) {
-                // 여러 권한 문자열 → SimpleGrantedAuthority 리스트 변환
                 authorities = Arrays.stream(authClaim.toString().split(","))
                         .map(SimpleGrantedAuthority::new)
                         .collect(Collectors.toList());
             } else {
-                // 권한 정보 없으면 기본 권한 할당
                 authorities = Arrays.asList(new SimpleGrantedAuthority("ROLE_USER"));
             }
-            // 인증 정보 객체 생성해서 반환 (principal/토큰/권한)
-            UserDetails principal = new User(claims.getSubject(), "", authorities);
+
+            // 사용자 이름 추출
+            String username = claims.getSubject();
+
+            // UserDetailsService에서 CustomUserDetails 조회
+            UserDetails principal = userDetailsService.loadUserByUsername(username);
+
             log.info("인증 정보 생성 완료");
-         // 최종적으로 Spring Security에서 사용할 Authentication 반환
-            return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+
+            // Authentication 객체 생성 및 반환
+            return new UsernamePasswordAuthenticationToken(principal, token, principal.getAuthorities());
+
         } catch (Exception e) {
             log.info("JWT 인증 정보 추출 중 오류가 발생했습니다. : " + e.getMessage());
             e.printStackTrace();

--- a/src/main/java/com/dialog/security/oauth2/OAuth2AuthenticationFailurHandler.java
+++ b/src/main/java/com/dialog/security/oauth2/OAuth2AuthenticationFailurHandler.java
@@ -31,7 +31,7 @@ public class OAuth2AuthenticationFailurHandler implements AuthenticationFailureH
 	       request.getSession().setAttribute("socialErrorMessage", errMsg);
 	       
 		   // 로그인 페이지로 리다이렉트
-	       response.sendRedirect("/login?social_error=true");
+	       response.sendRedirect("http://localhost:5500/login?social_error=true");
 
 				
 	}

--- a/src/main/java/com/dialog/user/controller/MeetUserController.java
+++ b/src/main/java/com/dialog/user/controller/MeetUserController.java
@@ -114,8 +114,7 @@ public class MeetUserController {
 	     return ResponseEntity.ok(Map.of(
 	         "name", dto.getName(),
 	         "email", dto.getEmail()
-	         
-	     ));
-	     
+	     ));	     
 	 }
+	 
 }

--- a/src/main/java/com/dialog/user/service/CustomUserDetails.java
+++ b/src/main/java/com/dialog/user/service/CustomUserDetails.java
@@ -1,0 +1,67 @@
+package com.dialog.user.service;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.dialog.user.domain.MeetUser;
+
+public class CustomUserDetails implements UserDetails {
+    private Long id; // DB 회원 고유 ID
+    private String username; // 이메일(로그인 아이디)
+    private String password; // 암호화된 비밀번호
+    private Collection<? extends GrantedAuthority> authorities; // 권한 목록
+
+    // 생성자: MeetUser 엔티티를 받아 필드 초기화
+    public CustomUserDetails(MeetUser user) {
+        this.id = user.getId(); // DB PK 저장
+        this.username = user.getEmail();
+        this.password = user.getPassword();
+        // 권한은 임시로 ROLE_USER 단일 권한 할당(필요시 user 권한 정보 사용 가능)
+        this.authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    // 사용자 ID를 가져오는 커스텀 getter (컨트롤러 등에서 사용 가능)
+    public Long getId() {
+        return id;
+    }
+
+    // 아래는 UserDetails 인터페이스 구현 메서드들
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+    @Override
+    public String getPassword() {
+        return password;
+    }
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    // 계정 만료 여부 (false면 만료)
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+    // 계정 잠금 여부 (false면 잠김)
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+    // 자격 증명(비밀번호) 만료 여부 (false면 비밀번호 만료)
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+    // 계정 활성화 여부 (false면 비활성화)
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/dialog/user/service/MeetuserService.java
+++ b/src/main/java/com/dialog/user/service/MeetuserService.java
@@ -24,17 +24,16 @@ public class MeetuserService {
 
     
 //      회원가입 처리 메서드
-//      @param dto 가입정보 DTO (이메일, 비번 등)
-//      흐름: 1) 약관 동의 체크 2) 이메일 중복 체크 3) 비번 암호화 및 DB저장
+//      가입정보 DTO (이메일, 비번 등)
+//      약관 동의 체크 -> 이메일 중복 체크 -> 비번 암호화 및 DB저장
 //      예외케이스 발생시: IllegalArgumentException, IllegalStateException 던짐 (글로벌 핸들러에서 catch됨)
-//      @throws Exception 가입에 실패 시 예외 발생
      
     public void signup(MeetUserDto dto) {
         // 1. 약관 동의 필수 검사
         if (dto.getTerms() == null || !dto.getTerms()) {
             throw new IllegalArgumentException("약관에 동의해야 가입할 수 있습니다.");
         }
-        // 2. 이메일 중복검사
+        // 2. 이메일 중복검사	
         if (meetUserRepository.existsByEmail(dto.getEmail())) {
             throw new IllegalStateException("이미 가입된 이메일입니다.");
         }
@@ -54,7 +53,7 @@ public class MeetuserService {
 //      현재 로그인한 유저 정보 조회 (SecurityContext 기반)
 //      @param authentication Spring Security 인증객체
 //      흐름:
-//       1) 인증 안됐으면 예외 발생
+//      1) 인증 안됐으면 예외 발생
 //      2) 소셜(OAuth2) 로그인과 일반 로그인 분기
 //         - OAuth2User면 provider, snsId로 회원 조회(DB)
 //         - UserDetails면 username(email)로 회원 조회(DB)
@@ -83,7 +82,7 @@ public class MeetuserService {
         } else {
             throw new IllegalArgumentException("알 수 없는 인증 방식입니다.");
         }
-        // Entity -> DTO 변환해 반환
+        // DTO -> Entity 변환해 반환
         return MeetUserDto.fromEntity(user);
     }
 

--- a/src/main/java/com/dialog/user/service/UserDetailsServiceImpl.java
+++ b/src/main/java/com/dialog/user/service/UserDetailsServiceImpl.java
@@ -3,9 +3,6 @@ package com.dialog.user.service;
 import java.util.Collection;
 import java.util.List;
 
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -20,32 +17,15 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class UserDetailsServiceImpl implements UserDetailsService {
 
-    private final MeetUserRepository userRepository;
+    private final MeetUserRepository userRepository; // DB 접근용 리포지토리
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-
-        // 1. 사용자명으로 DB에서 사용자 엔티티를 조회함
+        // 1. 데이터베이스에서 이메일(username) 기준으로 사용자 엔티티 조회
         MeetUser meetuser = userRepository.findByEmail(username)
           .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다. " + username));
 
-        // 2. UserDetails 객체 생성하여 Spring Security 인증 프로세스에 맞게 사용자 정보를 매핑
-        return User.builder()
-          .username(meetuser.getEmail()) // 사용자명 지정
-          .password(meetuser.getPassword()) // 암호화된 비밀번호 할당
-          .authorities(getAuthorities(meetuser)) // 권한 정보 할당
-          // 향후 계정 상태 관리에 따라 아래 설정 추가 가능
-//          .accountExpired(meetuser.isAccountExpired())
-//          .accountLocked(meetuser.isAccountLocked())
-//          .credentialsExpired(meetuser.isCredentialsExpired())
-//          .disabled(meetuser.isDisabled())
-          .build();
-    }
-
-    // 권한 정보를 Spring Security의 GrantedAuthority 컬렉션으로 변환
-    private Collection<? extends GrantedAuthority> getAuthorities(MeetUser meetuser) {
-        // 현재는 고정된 "ROLE_USER" 권한만 단일로 반환
-        return List.of(new SimpleGrantedAuthority("ROLE_USER"));
+        // 2. 커스텀 UserDetails 객체 생성하여 스프링 시큐리티가 인증에 사용할 수 있도록 반환
+        return new CustomUserDetails(meetuser);
     }
 }
-

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,8 +2,8 @@ server:
   port: 8080
 
 spring:
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
+  profiles:
+    active: local
 
   jpa:
     hibernate:
@@ -43,9 +43,6 @@ spring:
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
-
-  profiles:
-    include: secret
 
 logging:
   level:


### PR DESCRIPTION
CustomUserDetails 인터페이스 생성 하여 user 의 id 값 조회할수있도록 추가
JwtTokenProvider 에서 UserDetailsService 의존성 주입 하여 Security 의 User 말고 MeetUser의 User 를 조회하도록 명확히 구분
소셜로그인 실패 핸들러에서 실패시 리다이렉트 되는 url 을 프론트단 서버로 연결 
Meeting 엔티티 수정 및 keyword, participant 와의 관계 추가,
keyword,participant 엔티티 생성, Repository 에서 조회 메서드 추가 
MeetingController 작성 회의생성, 회의조회 컨트롤러 작성, 서비스단 작성, Repository 작성