### PR TITLE
feat:[BE] Google 캘린더 API 연동을 위한 Google Token 저장 및 발급 메서드 추가

### DIFF
--- a/src/main/java/com/dialog/AppConfig.java
+++ b/src/main/java/com/dialog/AppConfig.java
@@ -4,6 +4,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
 
 
 @Configuration
@@ -11,6 +14,20 @@ public class AppConfig {
 	@Bean
 	public PasswordEncoder passwordEncoder() {
 		return new BCryptPasswordEncoder(12);  // 비밀번호 12자 이상
+	}
+	
+	@Bean
+	public OAuth2AuthorizationRequestResolver customAuthorizationRequestResolver(
+	        ClientRegistrationRepository clientRegistrationRepository) {
+	    DefaultOAuth2AuthorizationRequestResolver resolver =
+	            new DefaultOAuth2AuthorizationRequestResolver(clientRegistrationRepository, "/oauth2/authorization");
+	    resolver.setAuthorizationRequestCustomizer(customizer -> customizer
+	            .additionalParameters(params -> {
+	                params.put("access_type", "offline");
+	                params.put("prompt", "consent");
+	            })
+	    );
+	    return resolver;
 	}
 	
 }

--- a/src/main/java/com/dialog/security/SecurityConfigJWT.java
+++ b/src/main/java/com/dialog/security/SecurityConfigJWT.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -30,6 +31,8 @@ public class SecurityConfigJWT {
 //    private final OAuth2AuthenticationSuccessHandler oAuth2successHandler;       // OAuth2 로그인 성공 핸들러
     private final CustomOAuth2UserService customOAuth2UserService;               // OAuth2UserService 커스텀 구현체
     private final JwtTokenProvider jwtTokenProvider;                             // JWT 토큰 생성/검증기
+    private final OAuth2AuthorizationRequestResolver customAuthorizationRequestResolver;
+
 
     @Bean
     public SecurityFilterChain meetFilterChain(HttpSecurity http) throws Exception {
@@ -60,13 +63,16 @@ public class SecurityConfigJWT {
             
             // 7. OAuth2 로그인 설정: 커스텀 서비스 및 성공/실패 핸들러 설정
             .oauth2Login(oauth2 -> oauth2
-                .loginPage("/login")                   // OAuth2 로그인 페이지 URL
-                .userInfoEndpoint(userInfo -> userInfo
-                    .userService(customOAuth2UserService)  // OAuth2 사용자 정보 서비스
-                )
-                .successHandler(oAuth2successHandler)   // 성공 시 처리 핸들러
-                .failureHandler(oAuth2faliureHandler)    // 실패 시 처리 핸들러
-            )
+            	    .loginPage("/login")
+            	    .userInfoEndpoint(userInfo -> userInfo
+            	        .userService(customOAuth2UserService)
+            	    )
+            	    .authorizationEndpoint(authz -> authz
+            	        .authorizationRequestResolver(customAuthorizationRequestResolver) 
+            	    )
+            	    .successHandler(oAuth2successHandler)
+            	    .failureHandler(oAuth2faliureHandler)
+            	)
             
             // 8. 로그아웃 비활성화 (필요시 활성화 가능)
             .logout(logout -> logout.disable())

--- a/src/main/java/com/dialog/token/domain/UserSocialToken.java
+++ b/src/main/java/com/dialog/token/domain/UserSocialToken.java
@@ -1,0 +1,44 @@
+package com.dialog.token.domain;
+
+import java.time.LocalDateTime;
+
+import com.dialog.user.domain.MeetUser;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "user_social_token")
+@Getter 
+@Setter 
+@NoArgsConstructor
+public class UserSocialToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private MeetUser user;
+
+    @Column(nullable = false, length = 50)
+    private String provider; // google, kakao, naver 등
+
+    @Column(length = 512)
+    private String accessToken;
+    @Column(length = 512)
+    private String refreshToken;
+    @Column
+    private LocalDateTime expiresAt;
+}

--- a/src/main/java/com/dialog/token/repository/UserSocialTokenRepository.java
+++ b/src/main/java/com/dialog/token/repository/UserSocialTokenRepository.java
@@ -1,0 +1,12 @@
+package com.dialog.token.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.dialog.token.domain.UserSocialToken;
+
+public interface UserSocialTokenRepository extends JpaRepository<UserSocialToken, Long> {
+	
+    Optional<UserSocialToken> findByUser_IdAndProvider(Long userId, String provider);
+}

--- a/src/main/java/com/dialog/token/service/UserTokenService.java
+++ b/src/main/java/com/dialog/token/service/UserTokenService.java
@@ -1,0 +1,11 @@
+package com.dialog.token.service;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import com.dialog.token.domain.UserSocialToken;
+
+public interface UserTokenService {
+    void saveGoogleTokens(Long userId, String accessToken, String refreshToken, LocalDateTime expiresAt);
+    Optional<UserSocialToken> findByUserIdAndProvider(Long userId, String provider);
+}

--- a/src/main/java/com/dialog/token/service/UserTokenServiceImpl.java
+++ b/src/main/java/com/dialog/token/service/UserTokenServiceImpl.java
@@ -1,0 +1,46 @@
+package com.dialog.token.service;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import com.dialog.token.domain.UserSocialToken;
+import com.dialog.token.repository.UserSocialTokenRepository;
+import com.dialog.user.domain.MeetUser;
+import com.dialog.user.repository.MeetUserRepository;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserTokenServiceImpl implements UserTokenService {
+
+    private final UserSocialTokenRepository userSocialTokenRepository;
+    private final MeetUserRepository meetUserRepository;
+
+    @Override
+    public void saveGoogleTokens(Long userId, String accessToken, String refreshToken, LocalDateTime expiresAt) {
+        Optional<UserSocialToken> tokenOpt = userSocialTokenRepository.findByUser_IdAndProvider(userId, "google");
+
+        UserSocialToken token = tokenOpt.orElseGet(() -> {
+            UserSocialToken newToken = new UserSocialToken();
+            MeetUser user = meetUserRepository.findById(userId)
+            	    .orElseThrow(() -> new EntityNotFoundException("User not found with id: " + userId));
+            newToken.setUser(user);
+            newToken.setProvider("google");
+            return newToken;
+        });
+
+        token.setAccessToken(accessToken);
+        token.setRefreshToken(refreshToken);
+        token.setExpiresAt(expiresAt);
+        userSocialTokenRepository.save(token);
+    }
+
+    @Override
+    public Optional<UserSocialToken> findByUserIdAndProvider(Long userId, String provider) {
+        return userSocialTokenRepository.findByUser_IdAndProvider(userId, provider);
+    }
+}

--- a/src/main/java/com/dialog/user/domain/MeetUser.java
+++ b/src/main/java/com/dialog/user/domain/MeetUser.java
@@ -1,25 +1,32 @@
 package com.dialog.user.domain;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.hibernate.annotations.CreationTimestamp;
 
+import com.dialog.token.domain.UserSocialToken;
+
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
 
-/**
- * 사용자 계정 정보를 담는 엔티티 클래스.
- * - 데이터베이스의 'user' 테이블과 직접 매핑되며, 애플리케이션의 핵심 데이터 모델입니다.
- * - @Getter: Lombok을 통해 모든 필드의 Getter 메서드를 자동 생성합니다.
- */
+
+ // 사용자 계정 정보를 담는 엔티티 클래스.
+ // - 데이터베이스의 'user' 테이블과 직접 매핑되며, 애플리케이션의 핵심 데이터 모델입니다.
+ // - @Getter: Lombok을 통해 모든 필드의 Getter 메서드를 자동 생성합니다.
+ 
 @Entity
 @Table(name = "user")
 @Getter
@@ -32,96 +39,109 @@ public class MeetUser {
     // 4. 소셜 로그인 정보
     // 5. 메타 정보 (생성일)
 
-    /**
-     * 1. 기본키(Primary Key)
-     * - @Id: 이 필드가 테이블의 기본키임을 나타냅니다.
-     * - @GeneratedValue: 기본키 값을 데이터베이스가 자동으로 생성하도록 설정합니다. (Auto Increment)
-     */
+    
+    //  1. 기본키(Primary Key)
+    //  - @Id: 이 필드가 테이블의 기본키임을 나타냅니다.
+    // - @GeneratedValue: 기본키 값을 데이터베이스가 자동으로 생성하도록 설정합니다. (Auto Increment)
+     
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-    /**
-     * 2-1. 이메일 (로그인 ID)
-     * - @Column: 테이블의 컬럼에 매핑되는 필드임을 나타냅니다.
-     * - nullable = false: 이 컬럼은 null 값을 허용하지 않습니다. (필수값)
-     * - unique = true: 이 컬럼의 값은 테이블 내에서 유일해야 합니다.
-     */
+    
+     //  2-1. 이메일 (로그인 ID)
+     //  - @Column: 테이블의 컬럼에 매핑되는 필드임을 나타냅니다.
+     //  - nullable = false: 이 컬럼은 null 값을 허용하지 않습니다. (필수값)
+     //  - unique = true: 이 컬럼의 값은 테이블 내에서 유일해야 합니다.
+     
 	@Column(nullable = false, length = 100, unique = true)
 	private String email;
 
-    /**
-     * 2-2. 비밀번호
-     * - 암호화된 형태로 저장되므로 길이를 넉넉하게 255자로 설정합니다.
-     */
+    
+    // 2-2. 비밀번호
+    //  - 암호화된 형태로 저장되므로 길이를 넉넉하게 255자로 설정합니다.
+     
 	@Column(nullable = false, length = 255)
 	private String password;
 
-    /**
-     * 3-1. 사용자 실명
-     */
+    
+    //  3-1. 사용자 실명
+     
 	@Column(nullable = false, length = 100)
 	private String name;
 
-    /**
-     * 3-2. 프로필 이미지 URL
-     * - 사용자가 프로필 사진을 설정했을 경우, 해당 이미지의 URL이 저장됩니다.
-     */
+    
+    //  3-2. 프로필 이미지 URL
+    // - 사용자가 프로필 사진을 설정했을 경우, 해당 이미지의 URL이 저장됩니다.
+     
 	@Column(length = 200)
 	private String profileImgUrl;
 
-    /**
-     * 3-3. 직무 (Job)
-     * - @Enumerated(EnumType.STRING): Enum 타입을 DB에 저장할 때, 순서(ORDINAL)가 아닌 이름(STRING)으로 저장합니다.
-     * (이유: 중간에 Enum 순서가 바뀌어도 DB 데이터가 깨지지 않아 훨씬 안전합니다.)
-     */
+    
+    // 3-3. 직무 (Job)
+    // - @Enumerated(EnumType.STRING): Enum 타입을 DB에 저장할 때, 순서(ORDINAL)가 아닌 이름(STRING)으로 저장합니다.
+    // (이유: 중간에 Enum 순서가 바뀌어도 DB 데이터가 깨지지 않아 훨씬 안전합니다.)
+     
 	@Enumerated(EnumType.STRING)
 	@Column(length = 50, nullable = false)
 	private Job job = Job.NONE; // 기본값으로 '정해지지 않음'을 설정
 
-    /**
-     * 3-4. 직급 (position)
-     * - 직무(Job) 필드와 동일한 이유로 EnumType.STRING을 사용합니다.
-     */
+    
+    // 3-4. 직급 (position)
+    // - 직무(Job) 필드와 동일한 이유로 EnumType.STRING을 사용합니다.
+     
 	@Enumerated(EnumType.STRING)
 	@Column(length = 50, nullable = false)
 	private Position position = Position.NONE; // 기본값으로 '정해지지 않음'을 설정
 
-    /**
-     * 4-1. 소셜 로그인 타입 (e.g., "google", "kakao")
-     */
+    
+    // 4-1. 소셜 로그인 타입 (e.g., "google", "kakao")
+     
 	@Column(length = 50)
 	private String socialType;
 
-    /**
-     * 4-2. 소셜 로그인 고유 ID
-     * - 각 소셜 플랫폼에서 제공하는 사용자의 고유 식별자입니다.
-     */
+    
+     // 4-2. 소셜 로그인 고유 ID
+     // - 각 소셜 플랫폼에서 제공하는 사용자의 고유 식별자입니다.
+     
 	@Column(length = 100)
 	private String snsId;
 
-    /**
-     * 5. 계정 생성일
-     * - @CreationTimestamp: 엔티티가 처음 저장될 때의 시간이 자동으로 기록됩니다.
-     * - updatable = false: 한 번 생성된 후에는 값이 수정되지 않습니다.
-     */
+    
+    //  5. 계정 생성일
+    //  - @CreationTimestamp: 엔티티가 처음 저장될 때의 시간이 자동으로 기록됩니다.
+    //  - updatable = false: 한 번 생성된 후에는 값이 수정되지 않습니다.
+     
 	@CreationTimestamp
 	@Column(name = "created_at", nullable = false, updatable = false)
 	private LocalDateTime createdAt;
 
-    /**
-     * JPA를 위한 기본 생성자.
-     * - JPA가 프록시 객체를 생성할 때 이 생성자를 사용합니다.
-     * - `protected`로 선언하여 외부에서 `new MeetUser()`와 같이 무분별하게 객체를 생성하는 것을 방지합니다.
-     */
+	// 소셜 토큰
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY,
+            cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<UserSocialToken> socialTokens = new ArrayList<>();
+    
+    // 소셜토큰 추가
+    public void addSocialToken(UserSocialToken token) {
+        socialTokens.add(token);
+        token.setUser(this);
+    }
+    
+    
+	
+    
+    //  JPA를 위한 기본 생성자.
+    //  - JPA가 프록시 객체를 생성할 때 이 생성자를 사용합니다.
+    //  - `protected`로 선언하여 외부에서 `new MeetUser()`와 같이 무분별하게 객체를 생성하는 것을 방지합니다.
+     
 	protected MeetUser() {
 	}
 
-	/**
-	 * @Builder: 빌더 패턴으로 객체를 생성할 수 있게 합니다.
-	 *  - 생성자의 파라미터 순서와 상관없이 명확하게 값을 할당할 수 있어 안전합니다.
-	 *  - 일반 회원가입 시에는 email, password, name만 사용됩니다.
-	 */
+	
+	//  @Builder: 빌더 패턴으로 객체를 생성할 수 있게 합니다.
+	//   - 생성자의 파라미터 순서와 상관없이 명확하게 값을 할당할 수 있어 안전합니다.
+	//   - 일반 회원가입 시에는 email, password, name만 사용됩니다.
+	 
 	@Builder
 	public MeetUser(String email, String password, String name, String socialType, String snsId, String profileImgUrl) {
 		this.email = email;
@@ -132,18 +152,39 @@ public class MeetUser {
 		this.profileImgUrl = profileImgUrl;
 	}
 
-	/**
-	 * 소셜 로그인 시, 기존 회원이 재로그인하면 프로필 정보(이름, 사진)를 업데이트하는 메서드.
-	 */
+	
+   
+    // 소셜 로그인 시, 기존 소셜 토큰 업데이트 메서드
+     
+    public void updateSocialToken(String provider, String accessToken, String refreshToken, LocalDateTime expiresAt) {
+        for (UserSocialToken token : socialTokens) {
+            if (token.getProvider().equals(provider)) {
+                token.setAccessToken(accessToken);
+                token.setRefreshToken(refreshToken);
+                token.setExpiresAt(expiresAt);
+                return;
+            }
+        }
+        // 없으면 새 토큰 추가
+        UserSocialToken newToken = new UserSocialToken();
+        newToken.setProvider(provider);
+        newToken.setAccessToken(accessToken);
+        newToken.setRefreshToken(refreshToken);
+        newToken.setExpiresAt(expiresAt);
+        addSocialToken(newToken);
+    }
+    
+    // 소셜 로그인 시, 기존 회원이 재로그인하면 프로필 정보(이름, 사진)를 업데이트하는 메서드.
+	 
 	public void updateSocialInfo(String name, String profileImgUrl) {
 		this.name = name;
 		this.profileImgUrl = profileImgUrl;
 	}
 
-	/**
-	 * '설정' 페이지에서 직무/직급 업데이트를 위한 메서드.
-	 * MeetuserService에서 호출됩니다.
-	 */
+	
+	 // '설정' 페이지에서 직무/직급 업데이트를 위한 메서드.
+	 //  MeetuserService에서 호출됩니다.
+	 
 	public void updateSettings(Job job, Position position) {
 		this.job = job;
 		this.position = position;


### PR DESCRIPTION
AppConfig
access_type=offline(리프레시 토큰 발급)과 prompt=consent(동의화면 강제 노출) 코드 추가

SecurityConfigJWT
소셜로그인 관련 필터체인 에서 AppConfig 에서 만들어둔 메서드 호출 ( 리프레쉬 토큰 발급을 위해)

OAuth2AuthenticationSuccessHandlerJWT
소셜로그인 성공 핸들러에서 구글 토큰(리프레쉬,어세스) 추출 및 저장 코드 추가

UserSocialToken
엔티티 생성 user 와 @ManyToOne 관계 설정

UserSocialTokenRepository 
리파지토리 생성 유저id 값과 소셜로그인 구분자 provider(Google,KaKao) 를 찾아오는 메서드 작성

UserTokenServiceImpl
UserTokenService
implements 함
구글 토큰 저장 로직과 유저id 값과 소셜로그인 구분자 provider(Google,KaKao) 를 찾아오는 메서드 호출

MeetUser 
UserSocialToken 과 @OneToMany 연관관계 설정 및 소셜토큰 추가 기능 메서드 추가
소셜 로그인시 기존 소셜 토큰 업데이트 메서드 작성

---

closes #14 