### PR TITLE
feat: [BE] 구글 캘린더 API 추가 기능

### DIFF
--- a/src/main/java/com/dialog/CalendarEvent/Service/GoogleCalendarApiClient.java
+++ b/src/main/java/com/dialog/CalendarEvent/Service/GoogleCalendarApiClient.java
@@ -14,6 +14,8 @@ import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.http.MediaType;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -27,40 +29,34 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor // WebClient 주입
 public class GoogleCalendarApiClient {
 
-	
 	private final WebClient webClient;
 	private static final String GOOGLE_CALENDAR_URL = "https://www.googleapis.com/calendar/v3/calendars/{calendarId}/events";
 	private static final DateTimeFormatter ISO_OFFSET_DATE_TIME = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
-	/**
-	 * Google Calendar API를 호출하여 지정된 기간의 이벤트를 조회합니다.
-	 */
-	public List<CalendarEventResponse> getEvents(String accessToken, String calendarId, 
-			LocalDateTime timeMin, LocalDateTime timeMax) {
 
-				// 1. Google API가 요구하는 ISO 8601 UTC 형식으로 변환
-				// Timezone을 시스템 기본값으로 설정하고 UTC로 변환하여 API 요청 파라미터를 만듭니다.
-				String timeMinStr = timeMin.atZone(ZoneId.systemDefault()).toInstant().atOffset(java.time.ZoneOffset.UTC)
-						.format(DateTimeFormatter.ISO_INSTANT);
-				String timeMaxStr = timeMax.atZone(ZoneId.systemDefault()).toInstant().atOffset(java.time.ZoneOffset.UTC)
-						.format(DateTimeFormatter.ISO_INSTANT);
+	public List<CalendarEventResponse> getEvents(String accessToken, String calendarId, LocalDateTime timeMin,
+			LocalDateTime timeMax) {
+
+		// 1. Google API가 요구하는 ISO 8601 UTC 형식으로 변환
+		// Timezone을 시스템 기본값으로 설정하고 UTC로 변환하여 API 요청 파라미터를 만듭니다.
+		String timeMinStr = timeMin.atZone(ZoneId.systemDefault()).toInstant().atOffset(java.time.ZoneOffset.UTC)
+				.format(DateTimeFormatter.ISO_INSTANT);
+		String timeMaxStr = timeMax.atZone(ZoneId.systemDefault()).toInstant().atOffset(java.time.ZoneOffset.UTC)
+				.format(DateTimeFormatter.ISO_INSTANT);
 
 		try {
 			// 2. WebClient를 사용하여 요청 구성 및 실행
-			GoogleEventResponseDTO eventsContainer = webClient.get()
-					.uri(GOOGLE_CALENDAR_URL, uriBuilder -> uriBuilder
+			GoogleEventResponseDTO eventsContainer = webClient.get().uri(GOOGLE_CALENDAR_URL, uriBuilder -> uriBuilder
 					// API 요구사항에 맞는 쿼리 파라미터 추가
-					.queryParam("timeMin", timeMinStr)
-					.queryParam("timeMax", timeMaxStr)
+					.queryParam("timeMin", timeMinStr).queryParam("timeMax", timeMaxStr)
 					.queryParam("singleEvents", true) // 반복 일정을 개별 이벤트로 확장
 					.queryParam("orderBy", "startTime") // 시작 시간 순으로 정렬
 					.build(calendarId)) // 경로 변수 {calendarId} 설정
 
 					// 3. Authorization: Bearer [accessToken] 헤더 설정
 					.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
-					
+
 					// 4. API 호출 및 응답 처리
-					.retrieve()
-					.onStatus(HttpStatusCode::isError, response -> {
+					.retrieve().onStatus(HttpStatusCode::isError, response -> {
 						log.error("Google Calendar API 호출 실패. Status: {}", response.statusCode());
 						// 오류 발생 시 사용자 정의 예외를 발생시킵니다.
 						// 이 단계에서 403, 401 오류 등을 잡아서 상위 레이어로 전달해야 합니다.
@@ -68,18 +64,16 @@ public class GoogleCalendarApiClient {
 								new RuntimeException("Google Calendar API 호출 중 오류 발생: " + response.statusCode()));
 					})
 					// 응답을 GoogleEventResponseDTO 컨테이너 객체로 파싱
-					.bodyToMono(GoogleEventResponseDTO.class)
-					.block(); // 동기적으로 결과 대기
+					.bodyToMono(GoogleEventResponseDTO.class).block(); // 동기적으로 결과 대기
 
 			// 5. 결과 검증 및 데이터 변환
 			if (eventsContainer == null || eventsContainer.getItems() == null) {
 				return Collections.emptyList();
 			}
 
-			// items 리스트를 가져와 CalendarEventDTO로 최종 변환합니다. 
+			// items 리스트를 가져와 CalendarEventDTO로 최종 변환합니다.
 			// (주의: GoogleEventResponseDTO 클래스 내부에 List<GoogleEventItemDTO> items가 있다고 가정)
-			return eventsContainer.getItems().stream()
-					.map(this::convertToCalendarEventDTO)
+			return eventsContainer.getItems().stream().map(this::convertToCalendarEventDTO)
 					.collect(Collectors.toList());
 
 		} catch (Exception e) {
@@ -93,28 +87,25 @@ public class GoogleCalendarApiClient {
 	public GoogleEventResponseDTO createEvent(String accessToken, String calendarId, GoogleEventRequestDTO requestDTO) {
 
 		if (requestDTO == null) {
-	        throw new IllegalArgumentException("Google Calendar 이벤트를 생성하기 위한 requestDTO가 null입니다. 상위 서비스 로직을 확인하세요.");
-	    }
-		
+			throw new IllegalArgumentException("Google Calendar 이벤트를 생성하기 위한 requestDTO가 null입니다. 상위 서비스 로직을 확인하세요.");
+		}
+
 		try {
 			GoogleEventResponseDTO responseBody = webClient.post() // POST 요청
 					.uri(GOOGLE_CALENDAR_URL, calendarId) // 캘린더 ID를 경로 변수로 설정
 
 					// 1. 헤더 설정: 인증 토큰 및 JSON 타입 명시
-					.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
-					.contentType(MediaType.APPLICATION_JSON)
+					.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken).contentType(MediaType.APPLICATION_JSON)
 
 					// 2. 요청 본문 설정: 일정 데이터를 JSON 형태로 보냅니다.
 					.bodyValue(requestDTO)
 
 					// 3. API 호출 및 응답 처리
-					.retrieve()
-					.onStatus(HttpStatusCode::isError, response -> {
+					.retrieve().onStatus(HttpStatusCode::isError, response -> {
 						log.error("Google Calendar 이벤트 생성 실패. Status: {}", response.statusCode());
 						return Mono.error(
 								new RuntimeException("Google Calendar API 생성 중 오류 발생: " + response.statusCode()));
-					})
-					.bodyToMono(GoogleEventResponseDTO.class) // 4. 응답 JSON을 DTO로 파싱
+					}).bodyToMono(GoogleEventResponseDTO.class) // 4. 응답 JSON을 DTO로 파싱
 					.block(); // 동기적으로 결과 대기
 
 			if (responseBody == null) {
@@ -134,44 +125,31 @@ public class GoogleCalendarApiClient {
 	 */
 	private CalendarEventResponse convertToCalendarEventDTO(GoogleEventResponseDTO googleEvent) {
 
-		EventDateTimeDTO startDateTimeDTO = (EventDateTimeDTO) googleEvent.getStart(); 
-		EventDateTimeDTO endDateTimeDTO = (EventDateTimeDTO) googleEvent.getEnd(); 
+		EventDateTimeDTO startDateTimeDTO = (EventDateTimeDTO) googleEvent.getStart();
+		EventDateTimeDTO endDateTimeDTO = (EventDateTimeDTO) googleEvent.getEnd();
 
 		LocalDateTime start = parseDateTime(startDateTimeDTO, true); // 시작 시간 파싱
-		
-		// (임시) 시간 정보는 null로 처리하고, 빌더 패턴을 사용하여 DTO를 생성합니다.
-		return CalendarEventResponse.builder()
-				// 1. Google Event ID -> CalendarEventDTO의 sourceId
-				.sourceId(googleEvent.getId())
 
-				// 2. Google Event Summary -> CalendarEventDTO의 title
+		String eventDateStr = null;
+		if (googleEvent.getStart().getDate() != null) {
+			// "YYYY-MM-DD" 형식의 문자열로 변환
+			eventDateStr = googleEvent.getStart().getDate().toString();
+		} else if (googleEvent.getStart().getDateTime() != null) {
+			eventDateStr = LocalDate
+					.parse(googleEvent.getStart().getDateTime().toString(), DateTimeFormatter.ISO_DATE_TIME).toString();
+		}
+
+		return CalendarEventResponse.builder().id(null) // Google 이벤트는 우리 DB ID가 없음
+				.userId(null)
 				.title(googleEvent.getSummary())
-
-				// 3. Google Event는 외부 이벤트이므로 로컬 DB ID는 null
-				.id(null)
-
-				// 4. 유형 (예: "GOOGLE" 또는 "PERSONAL"로 가정)
-				.type("GOOGLE")
-
-				// 5. 날짜와 시간 (Object 타입 변환의 복잡성 때문에 일단 null)
-				.date(start != null ? start.toLocalDate() : null)
-				// 종일 일정이면 LocalTime.MIN 대신 null을 넣는 것이 데이터 무결성에 더 좋을 수 있습니다.
-				.time(start != null && startDateTimeDTO.getDateTime() != null ? start.toLocalTime() : null) 
-
-				// 6. 중요 여부 (기본값 false로 가정)
+				.eventDate(eventDateStr)
+				.time(null)
+				.eventType("MEETING")
 				.isImportant(false)
-
-				.build(); // ⭐⭐⭐ new 생성자 대신 .builder() 호출 ⭐⭐⭐
+				.sourceId(googleEvent.getId()).googleEventId(googleEvent.getId()).createdAt(null) 
+				.build();
 	}
 
-	/**
-	 * EventDateTimeDTO에서 실제 LocalDateTime 또는 LocalDate를 추출하여 LocalDateTime으로 변환합니다.
-	 * - dateTime 필드가 있으면, 해당 필드(ISO 8601)를 파싱합니다. - date 필드가 있으면, 종일 일정으로 간주하고 해당
-	 * 날짜의 00:00(시작) 또는 다음 날 00:00(종료)로 파싱합니다.
-	 * 
-	 * @param dateTimeDTO EventDateTimeDTO (start 또는 end)
-	 * @return LocalDateTime
-	 */
 	private LocalDateTime parseDateTime(EventDateTimeDTO dateTimeDTO, boolean isStart) {
 		if (dateTimeDTO == null) {
 			return null;
@@ -181,7 +159,8 @@ public class GoogleCalendarApiClient {
 		if (dateTimeDTO.getDateTime() != null) {
 			try {
 				// ISO 8601 (예: 2025-10-23T10:00:00+09:00) 문자열을 파싱하여 시스템 ZoneId로 변환
-				return ZonedDateTime.parse(dateTimeDTO.getDateTime(), ISO_OFFSET_DATE_TIME).withZoneSameInstant(ZoneId.systemDefault()).toLocalDateTime();
+				return ZonedDateTime.parse(dateTimeDTO.getDateTime(), ISO_OFFSET_DATE_TIME)
+						.withZoneSameInstant(ZoneId.systemDefault()).toLocalDateTime();
 			} catch (java.time.format.DateTimeParseException e) {
 				log.error("Failed to parse dateTime: {}", dateTimeDTO.getDateTime(), e);
 				return null;
@@ -195,21 +174,12 @@ public class GoogleCalendarApiClient {
 			// 종일 일정의 'start'는 해당 날짜의 00:00:00
 			if (isStart) {
 				return localDate.atStartOfDay();
-			} 
-			// 종일 일정의 'end'는 Google이 다음 날 00:00:00으로 반환합니다.
-			// 이를 '종료일의 23:59:59.999...'로 변환하지 않고, API가 준대로 다음 날 00:00:00을 반환합니다.
-			// 클라이언트 측에서 렌더링 시 이 정보를 기반으로 처리합니다.
+			}
 			return localDate.atStartOfDay();
 		}
 		return null;
 	}
 
-	/**
-	 * 이벤트의 시작 시간 DTO를 기반으로 이벤트 유형(NORMAL 또는 ALL_DAY)을 결정합니다.
-	 * 
-	 * @param startDateTimeDTO 이벤트 시작 시간 DTO
-	 * @return EventType
-	 */
 	private EventType determineEventType(EventDateTimeDTO startDateTimeDTO) {
 		if (startDateTimeDTO != null && startDateTimeDTO.getDate() != null) {
 			return EventType.ALL_DAY; // date 필드가 있으면 종일 일정

--- a/src/main/java/com/dialog/CalendarEvent_/CalendarEventResponse.java
+++ b/src/main/java/com/dialog/CalendarEvent_/CalendarEventResponse.java
@@ -10,21 +10,69 @@ import java.time.LocalTime;
 @Builder // DTO 생성을 쉽게 하기 위해 Builder 패턴 사용
 public class CalendarEventResponse {
 
-	private final Long id;
-	private final Long userId; 
-	private final String title;
-	private final LocalDate date;
-	private final LocalTime time;
-	private final String type; // EventType (MEETING, TASK, PERSONAL)의 문자열 표현
-	private final boolean isImportant;
-	private final String sourceId; // taskId, meetingId, googleEventId 중 하나
-    private final LocalDateTime createdAt;
+//	private final Long id;
+//	private final Long userId; 
+//	private final String title;
+//	private final LocalDate date;
+//	private final LocalTime time;
+//	private final String type; // EventType (MEETING, TASK, PERSONAL)의 문자열 표현
+//	private final boolean isImportant;
+//	private final String sourceId; // taskId, meetingId, googleEventId 중 하나
+//    private final LocalDateTime createdAt;
 
 	/**
 	 * Entity를 Response DTO로 변환
 	 */
+//	public static CalendarEventResponse from(CalendarEvent entity) {
+//		String sourceId = null;
+//		if (entity.getEventType() == EventType.TASK && entity.getTaskId() != null) {
+//			sourceId = entity.getTaskId().toString();
+//		} else if (entity.getEventType() == EventType.MEETING && entity.getMeetingId() != null) {
+//			sourceId = entity.getMeetingId().toString();
+//		} else if (entity.getGoogleEventId() != null) {
+//			sourceId = entity.getGoogleEventId();
+//		}
+//
+//		return CalendarEventResponse.builder()
+//				.id(entity.getId())
+//				.userId(entity.getUserId())
+//				.title(entity.getTitle())
+//				.date(entity.getEventDate())
+//				.time(entity.getEventTime())
+//				.type(entity.getEventType().name())
+//				.isImportant(entity.isImportant())
+//				.sourceId(sourceId)
+//                .createdAt(entity.getCreatedAt())
+//				.build();
+//	}
+    
+    private final Long id;
+    private final Long userId; 
+    private final String title;
+    
+    // 🚨 [수정 1] JS가 "eventDate"라는 이름의 "String"을 기대합니다.
+    private final String eventDate; // LocalDate -> String
+    
+    private final LocalTime time; // (JS에서 사용 안 함)
+    
+    // 🚨 [수정 2] JS가 "eventType"이라는 이름을 기대합니다.
+    private final String eventType; // "type" -> "eventType"
+    
+    private final boolean isImportant;
+    private final String sourceId; 
+    private final String googleEventId; // ⭐️ JS가 사용할 googleEventId도 추가
+    private final LocalDateTime createdAt;
+
+	/**
+	 * Entity를 Response DTO로 변환
+     * ⭐️ JS가 기대하는 형식에 맞게 수정
+	 */
 	public static CalendarEventResponse from(CalendarEvent entity) {
-		String sourceId = null;
+		if (entity == null) {
+            return null;
+        }
+        
+        String sourceId = null;
 		if (entity.getEventType() == EventType.TASK && entity.getTaskId() != null) {
 			sourceId = entity.getTaskId().toString();
 		} else if (entity.getEventType() == EventType.MEETING && entity.getMeetingId() != null) {
@@ -37,11 +85,18 @@ public class CalendarEventResponse {
 				.id(entity.getId())
 				.userId(entity.getUserId())
 				.title(entity.getTitle())
-				.date(entity.getEventDate())
+                
+                // [수정 3] LocalDate -> "YYYY-MM-DD" String으로 변환
+                .eventDate(entity.getEventDate() != null ? entity.getEventDate().toString() : null)
+                
 				.time(entity.getEventTime())
-				.type(entity.getEventType().name())
+                
+                // [수정 4] 필드명을 "eventType"으로 변경
+				.eventType(entity.getEventType().name())
+                
 				.isImportant(entity.isImportant())
 				.sourceId(sourceId)
+                .googleEventId(entity.getGoogleEventId()) // ⭐️ googleEventId 매핑 추가
                 .createdAt(entity.getCreatedAt())
 				.build();
 	}

--- a/src/main/java/com/dialog/CalendarEvent_/GoogleEventRequestDTO.java
+++ b/src/main/java/com/dialog/CalendarEvent_/GoogleEventRequestDTO.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
 /**
  * JS의 const event = { ... } 객체와 직접적으로 매핑되는 DTO. Google Calendar API의 Event 객체
@@ -12,6 +13,7 @@ import lombok.Setter;
 
 @Getter
 @Setter
+@ToString
 public class GoogleEventRequestDTO {
 	private String summary;
 	private String description;

--- a/src/main/java/com/dialog/security/oauth2/OAuth2AuthenticationSuccessHandlerJWT.java
+++ b/src/main/java/com/dialog/security/oauth2/OAuth2AuthenticationSuccessHandlerJWT.java
@@ -106,7 +106,7 @@ public class OAuth2AuthenticationSuccessHandlerJWT extends SimpleUrlAuthenticati
            accessTokenCookie.setPath("/");
            accessTokenCookie.setHttpOnly(true);  // JS 접근 차단
            accessTokenCookie.setSecure(false);    // HTTPS 환경에서 true 
-           accessTokenCookie.setMaxAge(60 * 60 * 24); // 1일
+           accessTokenCookie.setMaxAge(60 * 60 * 24); // 1일           
            response.addCookie(accessTokenCookie);
 
            // 6. 리프레시 토큰 쿠키 설정


### PR DESCRIPTION
1. 캘린더 'To-do 생성' (POST) API 연동
2. calendar.js (addDailyTodo) → Controller (createEvent) → Service (createCalendarEvent) → Google API 연동 및 로컬 DB 저장
3. JSON 데이터 불일치로 인한 400/500 에러 해결. Service 로직에 DB 저장(save) 기능 누락된 부분 추가.
4. 캘린더 '조회' (GET) 및 UI 버그 수정
5. GET API 연동, DTO-JS 필드명/타입 일치, home.js/calendar.js 기능 병합, UI 렌더링 오류 수정
6. invalid_grant (401) 오류 시 Google 연동 팝업 표시. 12월/11월 날짜 표시 버그 수정. To-do 목록 갱신 오류 수정.