### PR TITLE
feat:[BE] 일반 회원 로그인 사용자 정보 저장 수정 및 관리자 페이지 기능 구현

### DIFF
--- a/src/main/java/com/dialog/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/dialog/meeting/repository/MeetingRepository.java
@@ -1,6 +1,11 @@
 package com.dialog.meeting.repository;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.dialog.meeting.domain.Meeting;
 import com.dialog.user.domain.MeetUser;
@@ -8,5 +13,19 @@ import com.dialog.user.domain.MeetUser;
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
 
 	void deleteByHostUser(MeetUser user);
+	
+	// 전체 회의수 반환
+	long count(); 
+	
+	// 이번 달 회의 생성 개수
+	@Query(value = "SELECT COUNT(*) FROM meeting WHERE created_at BETWEEN :start AND :end", nativeQuery = true)
+	long countMeetingsInMonth(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 
+	// 오늘 생성한 회의 수
+	@Query(value = "SELECT COUNT(*) FROM meeting WHERE created_at BETWEEN :start AND :end", nativeQuery = true)
+	long countTodayCreatedMeetings(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+
+	// 어제 생성한 회의 수
+	@Query(value = "SELECT COUNT(*) FROM meeting WHERE created_at BETWEEN :start AND :end", nativeQuery = true)
+	long countYesterdayCreatedMeetings(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 }

--- a/src/main/java/com/dialog/user/controller/AdminController.java
+++ b/src/main/java/com/dialog/user/controller/AdminController.java
@@ -5,11 +5,13 @@ import com.dialog.meeting.domain.MeetingCreateResponseDto;
 import com.dialog.meeting.service.MeetingService;
 import com.dialog.user.domain.AdminResponse;
 import com.dialog.user.domain.MeetUserDto;
+import com.dialog.user.domain.TodayStatsDto;
 import com.dialog.user.domain.UserSettingsUpdateDto;
 import com.dialog.user.service.AdminService;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,33 +21,40 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/admin")
 @RequiredArgsConstructor
 public class AdminController {
 
-    private final AdminService adminService;
+	private final AdminService adminService;
     private final MeetingService meetingService;
-
+    
+    // 관리자만 접근 가능하도록 PreAuthorize 적용 (ROLE_ADMIN 등)
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/users")
     public ResponseEntity<List<AdminResponse>> getAllUsers() {
         return ResponseEntity.ok(adminService.getAllUsers());
     }
     
+    @PreAuthorize("hasRole('ADMIN')")
     @DeleteMapping("/users/{userId}")
     public ResponseEntity<Void> deleteUser(@PathVariable("userId") Long userId) {    	
         adminService.deleteUser(userId);        
         return ResponseEntity.noContent().build();
     }
     
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/meetings")
     public ResponseEntity<List<MeetingCreateResponseDto>> getAllMeetings() {
         List<MeetingCreateResponseDto> meetings = meetingService.getAllMeetings();        
         return ResponseEntity.ok(meetings);
     }
     
+    @PreAuthorize("hasRole('ADMIN')")
     @PutMapping("/users/settings/{userId}")
     public ResponseEntity<Void> updateUserSettings(
             @PathVariable("userId") Long userId,
@@ -55,4 +64,40 @@ public class AdminController {
         return ResponseEntity.ok().build();
     }
     
-}
+    // 어드민 페이지 가입자 통계, 전체 회의수 조회 
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/statistics/users")
+    public ResponseEntity<Map<String, Object>> getUserStatistics() {
+        Map<String, Object> result = new HashMap<>();
+        result.put("totalUserCount", adminService.getTotalUserCount());
+        result.put("newUsersLast7Days", adminService.getNewUserCountLast7Days());
+        result.put("totalMeetingCount", adminService.getTotalMeetingCount());
+        result.put("meetingCountThisMonth", adminService.getMeetingCountThisMonth());
+        return ResponseEntity.ok(result);
+    }
+      
+    // 오늘 가입한 사용자
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/todayregisteruser")
+    public long getTodayRegisterUser() {
+        return adminService.countTodayRegisteredUsers();
+    }
+
+    // 오늘 생성한 회의	
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/todaycreatemeet")
+    public long getTodayCreateMeet() {
+        return adminService.countTodayCreatedMeetings();
+    }
+    
+    // 어제 오늘 생성, 가입 한 사용자 회의 차이수 조회
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/todaystats")
+    public TodayStatsDto getTodayStats() {
+        return adminService.getTodayStats();
+    }
+    
+    
+    
+    
+}  

--- a/src/main/java/com/dialog/user/controller/MeetUserController.java
+++ b/src/main/java/com/dialog/user/controller/MeetUserController.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -33,6 +34,8 @@ import com.dialog.user.domain.MeetUserDto;
 import com.dialog.user.domain.UserSettingsUpdateDto;
 import com.dialog.user.service.MeetuserService;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -66,47 +69,45 @@ public class MeetUserController {
 	
 	 // 2. 로그인
 	 @PostMapping(value = "/api/auth/login", produces = MediaType.APPLICATION_JSON_VALUE)
-	 public ResponseEntity<?> login(@RequestBody LoginDto dto) {
+	 public ResponseEntity<?> login(@RequestBody LoginDto dto, HttpServletResponse response) {
 	     Map<String, Object> result = new HashMap<>();
 	     try {
-	         // 1. 클라이언트가 전달한 이메일과 비밀번호로 사용자 인증 수행
 	         MeetUser user = meetuserService.login(dto.getEmail(), dto.getPassword());
-	
-	         // 2. Spring Security 인증 객체 생성
+
 	         Authentication authentication = new UsernamePasswordAuthenticationToken(
-	        		    user.getEmail(), null, 
-	        		    List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()))
-    		 );
-	
-	         // 3. 인증 정보를 기반으로 JWT 액세스 토큰 생성
+	             user.getEmail(), null, 
+	             List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()))
+	        );
+
 	         String token = jwtTokenProvider.createToken(authentication);
-	
-	         // 4. 리프레시 토큰 생성 및 DTO 변환 - 사용자 정보와 연동하여 DB에 저장됨
+
+	         Cookie jwtCookie = new Cookie("jwt", token);
+	         jwtCookie.setHttpOnly(true);
+	         jwtCookie.setPath("/");
+	         jwtCookie.setMaxAge(60 * 60 * 3); // 3시간, 필요에 따라 조정
+	         // 추후 운영에서 true 로 설정 
+	         jwtCookie.setSecure(false);
+	         response.addCookie(jwtCookie);
+
 	         RefreshTokenDto refreshTokenDto = refreshTokenService.createRefreshTokenDto(user);
-	
-	         // 5. 클라이언트에게 반환할 응답 데이터 구성
-	         result.put("success", true);  // 처리 성공 상태
-	         result.put("token", token);   // 새로 발급된 JWT 액세스 토큰
-	         result.put("refreshToken", refreshTokenDto.getRefreshToken());           // 리프레시 토큰 문자열
-	         result.put("refreshTokenExpiresAt", refreshTokenDto.getExpiresAt());     // 리프레시 토큰 만료시간
+
+	         result.put("success", true);
+	         result.put("token", token);
+	         result.put("refreshToken", refreshTokenDto.getRefreshToken());
+	         result.put("refreshTokenExpiresAt", refreshTokenDto.getExpiresAt());
 	         result.put("message", "로그인 성공");
-	         // 사용자 기본 정보(name, email) JSON 형태로 포함
 	         result.put("user", Map.of(
-	                 "name", user.getName(),
-	                 "email", user.getEmail(),
-	                 "role", user.getRole().name()
-	             ));
-	
-	         // 6. 성공 응답으로 클라이언트에 JSON 반환
+	              "name", user.getName(),
+	              "email", user.getEmail(),
+	              "role", user.getRole().name()
+	         ));
 	         return ResponseEntity.ok(result);
 	     } catch (IllegalStateException e) {
-	         // 7. 인증 실패 시 에러 응답 생성
 	         result.put("success", false);
 	         result.put("message", e.getMessage());
 	         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(result);
 	     }
 	 }
-	
 	 //3.현재 로그인된 사용자 정보 조회
 	 @GetMapping("/api/auth/me")
 	 public ResponseEntity<?> getCurrentUserInfo(Authentication authentication) {

--- a/src/main/java/com/dialog/user/domain/TodayStatsDto.java
+++ b/src/main/java/com/dialog/user/domain/TodayStatsDto.java
@@ -1,0 +1,21 @@
+package com.dialog.user.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+// 오늘 가입한 사용자 및 오늘 생성한 회의 조회
+// 어제 오늘 가입 사용자 생성 회의 차이를 비교하기 위한 DTO
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TodayStatsDto {
+	
+    private long todayCreateMeetCount;
+    private long todayCreateMeetChange;
+    private long todayRegisterUserCount;
+    private long todayRegisterUserChange;
+    
+}

--- a/src/main/java/com/dialog/user/repository/MeetUserRepository.java
+++ b/src/main/java/com/dialog/user/repository/MeetUserRepository.java
@@ -1,8 +1,11 @@
 package com.dialog.user.repository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.dialog.user.domain.MeetUser;
 
@@ -16,4 +19,19 @@ public interface MeetUserRepository extends JpaRepository<MeetUser, Long> {
 
     boolean existsByEmail(String email);
 
+    
+    // 전체 가입자 수 (쿼리)
+    long count();
+
+    // 최근 7일간 가입자 수
+    int countByCreatedAtAfter(LocalDateTime date);
+    
+    // 오늘 하루 가입자 수 - 범위 검색 (00:00:00 ~ 23:59:59)
+    @Query(value = "SELECT COUNT(*) FROM user WHERE created_at BETWEEN :start AND :end", nativeQuery = true)
+    long countTodayRegisteredUsers(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+
+    // 어제 가입자 수 - 범위 검색
+    @Query(value = "SELECT COUNT(*) FROM user WHERE created_at BETWEEN :start AND :end", nativeQuery = true)
+    long countYesterdayRegisteredUsers(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+    
 }


### PR DESCRIPTION
## **구현 기능 요약**
* 로그인 시 일반 회원 로그인 사용자 정보 저장 코드 추가
* 관리자 페이지 가입자통계, 전체 회의수, 오늘 생성회의, 오늘 신규가입 사용자 조회하는 메서드 구현

---

## **개발 내역 상세**
* MeetUserController 에서 일반 회원 로그인 시 JWT 토큰 발급하여 쿠키에 저장하는 로직 추가
* AdminController -> 가입자 통계, 전체 회의수 조회 api 요청 구현
* AdminService -> MeetUser, Meeting Repository 에서 구현한 조회 메서드 호출
* MeetUserRepository -> 전체 가입자, 최근 7일 가입자 수, 오늘 하루 가입자 수, 어제 가입자 수 조회 메서드 네이티브 쿼리 사용하여 구현
* MeetingRepository  -> 전체회의수, 이번달 생성 회의 수, 오늘 생성한 회의 수, 어제 생성한 회의 수 조회 메서드 구현

---

## **검증 방법**
* 새로 회원 가입 후 회원가입 유저 수 회의 수 증가 확인

---

## **추가 개선 / TODO**
* 다음 작업: 어드민 페이지 에서 필요한 기능들 더있을 고민 후 추가 구현 예정
