### PR TITLE
feat[BE] 전역 예외 처리 리팩토링 및 401 오류 수정

### DIFF
--- a/src/main/java/com/dialog/WebConfig.java
+++ b/src/main/java/com/dialog/WebConfig.java
@@ -6,12 +6,13 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
-    @Override
-    public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/api/**") // /api로 시작하는 모든 경로에 대해 CORS 적용
-            .allowedOrigins("http://localhost:5500", "http://127.0.0.1:5500", "http://localhost:5501", "http://127.0.0.1:5501") // 허용할 프론트엔드 출처 지정.
-             // 실제 사용할 HTTP 메서드만 명시(예: GET, POST 등). *대신 "*"이면 모두 허용
-            .allowedMethods("*") // 모든 HTTP 메서드 허용 ("GET", "POST", "PUT" 등). 운영환경에선 보안 위해 필요한 메서드만 지정 권장
-            .allowCredentials(true); // 인증정보(쿠키, 인증 헤더 등) 포함 요청 허용. OAuth/JWT/SameSite 세션 등에 필요
-    }
+	@Override
+	public void addCorsMappings(CorsRegistry registry) {
+		registry.addMapping("/api/**") // /api로 시작하는 모든 경로에 대해 CORS 적용
+				.allowedOrigins("http://localhost:5500", "http://127.0.0.1:5500", "http://localhost:5501",
+						"http://127.0.0.1:5501") // 허용할 프론트엔드 출처 지정.
+				// 실제 사용할 HTTP 메서드만 명시(예: GET, POST 등). *대신 "*"이면 모두 허용
+				.allowedMethods("*") // 모든 HTTP 메서드 허용 ("GET", "POST", "PUT" 등). 운영환경에선 보안 위해 필요한 메서드만 지정 권장
+				.allowCredentials(true); // 인증정보(쿠키, 인증 헤더 등) 포함 요청 허용. OAuth/JWT/SameSite 세션 등에 필요
+	}
 }

--- a/src/main/java/com/dialog/calendarevent/controller/CalendarEventController.java
+++ b/src/main/java/com/dialog/calendarevent/controller/CalendarEventController.java
@@ -40,165 +40,83 @@ public class CalendarEventController {
 	private final SocialTokenService tokenManagerService;
 
 	@GetMapping("/calendar/events")
-	public ResponseEntity<?> getEvents(Principal principal,
-
+	public ResponseEntity<List<CalendarEventResponse>> getEvents(Principal principal, // ResponseEntity<?> ->
+																						// ResponseEntity<List<CalendarEventResponse>>
 			@RequestParam(name = "startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
-
 			@RequestParam(name = "endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
 
 		if (principal == null) {
 			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
 		}
 
-		String userEmail = principal.getName();
-		try {
-			List<CalendarEventResponse> events = calendarEventService.getEventsByDateRange(userEmail, startDate,
-					endDate);
-
-			return ResponseEntity.ok(events);
-
-		} catch (IllegalAccessException e) {
-
-			return ResponseEntity.status(HttpStatus.FORBIDDEN).build(); // 403 Forbidden
-
-		} catch (Exception e) {
-
-			if (e.getMessage() != null
-					&& (e.getMessage().contains("invalid_grant") || e.getMessage().contains("Google 토큰 갱신 실패")
-							|| e.getMessage().contains("Access Token이 유효하지 않거나 비어있습니다"))) {
-
-				log.warn("⚠️ Google 토큰 갱신 실패(invalid_grant). 401 상태와 재연동 코드를 반환합니다.");
-
-				Map<String, String> errorResponse = new HashMap<>();
-				errorResponse.put("errorCode", "GOOGLE_REAUTH_REQUIRED");
-				errorResponse.put("message", "Google 토큰이 만료되었거나 무효화되었습니다. 계정 재연동이 필요합니다.");
-
-				return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse); // ⭐️ 401 + JSON 반환
-			}
-
-			e.printStackTrace();
-			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-		}
+		List<CalendarEventResponse> events = calendarEventService.getEventsByDateRange(principal.getName(), startDate,
+				endDate);
+		return ResponseEntity.ok(events);
 	}
 
 	@PostMapping("/calendar/events")
 	public ResponseEntity<GoogleEventResponseDTO> createEvent(Principal principal,
 			@RequestBody @Valid CalendarCreateRequest request) {
-		try {
 
-			if (request == null || request.getEventData() == null) {
-				return ResponseEntity.badRequest().build(); // 400 Bad Request 반환
-			}
-
-			String userEmail = principal.getName();
-			String provider = "google";
-
-			String accessToken = tokenManagerService.getToken(userEmail, provider);
-
-			String calendarId = request.getCalendarId();
-
-			// 2. 만약 null이거나 비어있다면, "primary"를 기본값으로 사용합니다.
-			if (calendarId == null || calendarId.isBlank()) {
-				calendarId = "primary";
-			}
-			GoogleEventResponseDTO response = calendarEventService.createCalendarEvent(userEmail, // principalName
-					provider, // provider
-					calendarId,
-					accessToken, // accessToken
-					request.getEventData() // GoogleEventRequestDTO
-			);
-
-			return ResponseEntity.ok(response);
-
-		} catch (IllegalArgumentException e) {
-			// 토큰 획득/유효성 검증 오류 시
-			return ResponseEntity.status(HttpStatus.BAD_REQUEST).build(); // 400 Bad Request
-
-		} catch (Exception e) {
-			e.printStackTrace();
-			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+		if (principal == null) {
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
 		}
+		if (request == null || request.getEventData() == null) {
+			// 400 Bad Request를 유발 (GlobalExceptionHandler가 처리)
+			throw new IllegalArgumentException("이벤트 데이터가 비어있습니다.");
+		}
+
+		String userEmail = principal.getName();
+		String provider = "google";
+
+		// 서비스에서 토큰 관련 예외(GoogleOAuthException)를 던질 것으로 기대
+		String accessToken = tokenManagerService.getToken(userEmail, provider);
+
+		String calendarId = request.getCalendarId();
+		if (calendarId == null || calendarId.isBlank()) {
+			calendarId = "primary";
+		}
+		GoogleEventResponseDTO response = calendarEventService.createCalendarEvent(userEmail, provider, calendarId,
+				accessToken, request.getEventData());
+		return ResponseEntity.ok(response);
 	}
 
 	@PutMapping("/calendar/events/{id}")
-	public ResponseEntity<?> updateEvent(Principal principal, @PathVariable("id") String eventId,
+	public ResponseEntity<GoogleEventResponseDTO> updateEvent(Principal principal, @PathVariable("id") String eventId,
 			@RequestBody @Valid CalendarCreateRequest request) {
 
 		if (principal == null) {
 			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
 		}
 
-		try {
-			String userEmail = principal.getName();
-			String provider = "google";
+		String userEmail = principal.getName();
+		String provider = "google";
 
-			String calendarId = request.getCalendarId();
-			if (calendarId == null || calendarId.isBlank()) {
-				calendarId = "primary";
-			}
-			
-			GoogleEventResponseDTO updatedEvent = calendarEventService.updateCalendarEvent(userEmail, provider,
-					calendarId, eventId, // 업데이트할 이벤트의 ID
-					request.getEventData() // 새로운 이벤트 정보
-			);
-
-			return ResponseEntity.ok(updatedEvent);
-
-		} catch (IllegalAccessException e) {
-			return ResponseEntity.status(HttpStatus.FORBIDDEN).build(); // 403
-
-		} catch (Exception e) {
-			if (e.getMessage() != null
-					&& (e.getMessage().contains("invalid_grant") || e.getMessage().contains("Google 토큰 갱신 실패"))) {
-
-				log.warn("⚠️ Google 토큰 갱신 실패(invalid_grant). 401 상태와 재연동 코드를 반환합니다.");
-				Map<String, String> errorResponse = new HashMap<>();
-				errorResponse.put("errorCode", "GOOGLE_REAUTH_REQUIRED");
-				errorResponse.put("message", "Google 토큰이 만료되었거나 무효화되었습니다. 계정 재연동이 필요합니다.");
-				return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse); // ⭐️ 401 + JSON 반환
-			}
-			log.error("Error updating event: " + eventId, e);
-			e.printStackTrace();
-			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+		String calendarId = request.getCalendarId();
+		if (calendarId == null || calendarId.isBlank()) {
+			calendarId = "primary";
 		}
+		GoogleEventResponseDTO updatedEvent = calendarEventService.updateCalendarEvent(userEmail, provider, calendarId,
+				eventId, request.getEventData());
+
+		return ResponseEntity.ok(updatedEvent);
 	}
-	
+
 	@DeleteMapping("/calendar/events/{id}")
-	public ResponseEntity<?> deleteEvent(
-	        Principal principal,
-	        @PathVariable("id") String eventId) { // URL 경로의 이벤트 ID 받기
+	public ResponseEntity<Void> deleteEvent(Principal principal, @PathVariable("id") String eventId) {
 
-	    if (principal == null) {
-	        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-	    }
+		if (principal == null) {
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+		}
+		calendarEventService.deleteCalendarEvent(principal.getName(), eventId);
 
-	    try {
-	        String userEmail = principal.getName();	        
-	        calendarEventService.deleteCalendarEvent(userEmail, eventId);
-	        return ResponseEntity.ok().build(); 
-
-	    } catch (IllegalAccessException e) {
-	        return ResponseEntity.status(HttpStatus.FORBIDDEN).build(); // 403 (권한 없음)
-	    
-	    } catch (RuntimeException e) {	        
-	        if (e.getMessage() != null && e.getMessage().contains("invalid_grant")) {	            
-	            Map<String, String> errorResponse = new HashMap<>();
-	            errorResponse.put("errorCode", "GOOGLE_REAUTH_REQUIRED");
-	            errorResponse.put("message", "Google 토큰이 만료되었거나 무효화되었습니다. 계정 재연동이 필요합니다.");
-	            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
-	        }	        
-	        
-	        if (e.getMessage() != null && e.getMessage().contains("로컬 이벤트를 찾을 수 없습니다")) {
-	             return ResponseEntity.status(HttpStatus.NOT_FOUND).build(); // 404
-	        }
-	        log.error("Error deleting event: " + eventId, e);
-	        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-	    }
+		return ResponseEntity.ok().build();
 	}
+
 	// 캘린더 중요도 표시 하는 API
 	@PatchMapping("/{eventId}/importance")
-    public ResponseEntity<Void> toggleImportance(@PathVariable Long eventId) {
-        calendarEventService.toggleImportance(eventId);
-        return ResponseEntity.ok().build();
-    }
+	public ResponseEntity<Void> toggleImportance(@PathVariable Long eventId) { 
+		calendarEventService.toggleImportance(eventId);
+		return ResponseEntity.ok().build();
+	}
 }

--- a/src/main/java/com/dialog/calendarevent/domain/CalendarEventResponse.java
+++ b/src/main/java/com/dialog/calendarevent/domain/CalendarEventResponse.java
@@ -16,7 +16,7 @@ public class CalendarEventResponse {
 
 	private final String eventDate;
 
-	private final LocalTime time; 
+	private final LocalTime time;
 	private final String eventType;
 
 	private final boolean isImportant;
@@ -40,10 +40,7 @@ public class CalendarEventResponse {
 
 		return CalendarEventResponse.builder().id(entity.getId()).userId(entity.getUserId()).title(entity.getTitle())
 				.eventDate(entity.getEventDate() != null ? entity.getEventDate().toString() : null)
-
-				.time(entity.getEventTime())
-				.eventType(entity.getEventType().name())
-				.isImportant(entity.isImportant()).sourceId(sourceId).googleEventId(entity.getGoogleEventId())
-				.createdAt(entity.getCreatedAt()).build();
+				.time(entity.getEventTime()).eventType(entity.getEventType().name()).isImportant(entity.isImportant())
+				.sourceId(sourceId).googleEventId(entity.getGoogleEventId()).createdAt(entity.getCreatedAt()).build();
 	}
 }

--- a/src/main/java/com/dialog/calendarevent/domain/EventDateTimeDTO.java
+++ b/src/main/java/com/dialog/calendarevent/domain/EventDateTimeDTO.java
@@ -3,10 +3,6 @@ package com.dialog.calendarevent.domain;
 import lombok.Getter;
 import lombok.Setter;
 
-/**
- * JS의 start: { 'date': 'YYYY-MM-DD' } 구조와 매핑되는 DTO. Google Calendar API 형식에 맞추어
- * 날짜 문자열을 받습니다.
- */
 @Getter
 @Setter
 public class EventDateTimeDTO {

--- a/src/main/java/com/dialog/exception/GoogleOAuthException.java
+++ b/src/main/java/com/dialog/exception/GoogleOAuthException.java
@@ -1,0 +1,23 @@
+package com.dialog.exception;
+
+public class GoogleOAuthException extends RuntimeException {
+	
+	// 1. 구글 OAuth 인증 실패 예외 (401)
+	public GoogleOAuthException(String message) {
+        super(message);
+    }
+	
+	// 2. 리소스를 찾을 수 없음 예외 (404) - Optional
+	public static class ResourceNotFoundException extends RuntimeException {
+	    public ResourceNotFoundException(String message) {
+	        super(message);
+	    }
+	}
+	
+	// 3. 권한 없음 예외 (403) - Optional (기존 IllegalAccessException 대체용)
+	public static class AccessDeniedException extends RuntimeException {
+	    public AccessDeniedException(String message) {
+	        super(message);
+	    }
+	}
+}

--- a/src/main/java/com/dialog/exception/dto/ErrorResponse.java
+++ b/src/main/java/com/dialog/exception/dto/ErrorResponse.java
@@ -1,0 +1,11 @@
+package com.dialog.exception.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+	private String errorCode;
+    private String message;
+}

--- a/src/main/java/com/dialog/meeting/domain/Meeting.java
+++ b/src/main/java/com/dialog/meeting/domain/Meeting.java
@@ -34,89 +34,83 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "meeting")
-@Getter 
-@NoArgsConstructor(access = AccessLevel.PROTECTED) 
-@AllArgsConstructor 
-@Builder(toBuilder = true) 
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder(toBuilder = true)
 public class Meeting {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
-	
+
 	@Column(nullable = false, length = 255)
 	private String title; // 회의 제목
-	
-	@Lob 
+
+	@Lob
 	private String description; // 회의 설명
-	
+
 	@Column(name = "scheduled_at", nullable = false)
 	private LocalDateTime scheduledAt; // 예약된 회의 시작 시간
-	
+
 	@Column(name = "started_at")
 	private LocalDateTime startedAt; // 실제 회의 시작 시간
-	
+
 	@Column(name = "ended_at")
 	private LocalDateTime endedAt; // 실제 회의 종료 시간
-	
-	@Enumerated(EnumType.STRING) 
+
+	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
-	    @Builder.Default 
+	@Builder.Default
 	private Status status = Status.SCHEDULED; // 회의 상태
-	
+
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "host_user_id", nullable = false) 
+	@JoinColumn(name = "host_user_id", nullable = false)
 	private MeetUser hostUser; // 회의 주최자 (MeetUser 엔티티 참조)
-	
+
 	@Lob
 	private String summary; // AI 회의 요약본
-	
+
 	@CreationTimestamp // 엔티티 생성 시 자동으로 현재 시간 저장
 	@Column(name = "created_at", nullable = false, updatable = false)
 	private LocalDateTime createdAt; // 레코드 생성 일시
-	
+
 	@UpdateTimestamp // 엔티티 수정 시 자동으로 현재 시간 저장
 	@Column(name = "updated_at", nullable = false)
 	private LocalDateTime updatedAt; // 레코드 마지막 수정 일시
-	
+
 	@OneToMany(mappedBy = "meeting", fetch = FetchType.LAZY)
 	private List<Participant> participants;
-	
-  // 키워드 연관관계 (다대다)
+
+	// 키워드 연관관계 (다대다)
 	@Builder.Default
-    @ManyToMany
-    @JoinTable(
-        name = "MeetingKeyword",
-        joinColumns = @JoinColumn(name = "meeting_id"),
-        inverseJoinColumns = @JoinColumn(name = "keyword_id")
-    )
-    private List<Keyword> keywords = new ArrayList<>();
-     
-    public void updateInfo(String title, String description) {
-        if (title != null) {
-            this.title = title;
-        }
-        if (description != null) {
-            this.description = description;
-        }
-    }
-   
-    //  회의 상태를 '녹음 중(RECORDING)'으로 변경하고 시작 시간을 기록합니다.     
-    public void startRecording() {
-        this.status = Status.RECORDING;
-        this.startedAt = LocalDateTime.now(); 
-    }
+	@ManyToMany
+	@JoinTable(name = "MeetingKeyword", joinColumns = @JoinColumn(name = "meeting_id"), inverseJoinColumns = @JoinColumn(name = "keyword_id"))
+	private List<Keyword> keywords = new ArrayList<>();
 
-    
-    //  회의 상태를 '완료(COMPLETED)'로 변경하고 종료 시간을 기록합니다.
-    public void complete() {
-        this.status = Status.COMPLETED;
-        this.endedAt = LocalDateTime.now(); 
-    }
+	public void updateInfo(String title, String description) {
+		if (title != null) {
+			this.title = title;
+		}
+		if (description != null) {
+			this.description = description;
+		}
+	}
 
+	// 회의 상태를 '녹음 중(RECORDING)'으로 변경하고 시작 시간을 기록합니다.
+	public void startRecording() {
+		this.status = Status.RECORDING;
+		this.startedAt = LocalDateTime.now();
+	}
 
-    // AI 요약본을 업데이트합니다.
-    public void updateSummary(String newSummary) {
-        this.summary = newSummary;
-    }
+	// 회의 상태를 '완료(COMPLETED)'로 변경하고 종료 시간을 기록합니다.
+	public void complete() {
+		this.status = Status.COMPLETED;
+		this.endedAt = LocalDateTime.now();
+	}
+
+	// AI 요약본을 업데이트합니다.
+	public void updateSummary(String newSummary) {
+		this.summary = newSummary;
+	}
 }

--- a/src/main/java/com/dialog/token/service/SocialTokenService.java
+++ b/src/main/java/com/dialog/token/service/SocialTokenService.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import com.dialog.exception.GoogleOAuthException;
+import com.dialog.exception.GoogleOAuthException.ResourceNotFoundException; 
 import com.dialog.calendarevent.service.GoogleTokenDto;
 import com.dialog.googleauth.domain.GoogleAuthDTO;
 import com.dialog.token.domain.UserSocialToken;
@@ -29,15 +31,14 @@ public class SocialTokenService {
 	
 	private final GoogleAuthDTO googleAuthDTO;
 
-	public String getToken(String userEmail, String provider) throws IllegalArgumentException {
+	public String getToken(String userEmail, String provider){
 	    
 	    // 1. User Email을 통해 MeetUser 엔티티를 조회하고 ID를 얻습니다.
 	    // 사용자를 찾을 수 없는 경우 IllegalArgumentException 발생
 	    MeetUser meetUser = meetUserRepository.findByEmail(userEmail)
 	                        .orElseThrow(() -> {
 	                            log.error("MeetUser를 찾을 수 없습니다: {}", userEmail);
-	                            // IllegalAccessException 대신 IllegalArgumentException 사용
-	                            return new IllegalArgumentException("MeetUser를 찾을 수 없습니다: " + userEmail); 
+	                            return new ResourceNotFoundException("User를 찾을 수 없습니다: " + userEmail); 
 	                        });
 	    
 	    Long userId = meetUser.getId(); // MeetUser의 ID(PK) 획득
@@ -45,67 +46,81 @@ public class SocialTokenService {
 	    if (socialTokenOpt.isEmpty()) {
 	        log.warn("사용자 ID {} (Email: {})에 대한 {} Refresh Token이 DB에 없습니다. Google 연동이 필요합니다.", 
 	                 userId, userEmail, provider);
-	        throw new IllegalArgumentException(provider + " 연동 토큰이 없습니다. 먼저 계정 연동을 완료해야 합니다.");
+	        // [ 3. 수정 ] (400 에러 원인) IllegalArgumentException 대신 GoogleOAuthException 사용 (401 유발)
+	        throw new GoogleOAuthException(provider + " 연동 토큰이 없습니다. 먼저 계정 연동을 완료해야 합니다.");
 	    }
+
 	    UserSocialToken socialToken = socialTokenOpt.get();
 	    String refreshToken = socialToken.getRefreshToken();
 	  
+	    // 만료 시간 체크 (현재 시간보다 5분 이상 남았으면 갱신 안 함)
+	    if (socialToken.getExpiresAt() != null && socialToken.getExpiresAt().isAfter(LocalDateTime.now().plusMinutes(5))) {
+            log.debug("Access Token이 유효하여 갱신 없이 반환합니다.");
+	        return socialToken.getAccessToken();
+	    }
+	    log.debug("Access Token이 만료되었거나 만료 직전이므로 갱신을 시도합니다.");
 	    return this.refreshAccessToken(refreshToken, provider.toLowerCase(),userId, socialToken);
 	}
 
-    private String refreshAccessToken(String refreshToken, String provider, Long userId, UserSocialToken socialToken) {
-    	
-    	GoogleAuthDTO.ProviderConfig config = googleAuthDTO.getProvider()
-                .get(provider);   	
-    	
-        log.info("API CALL: {} 토큰 엔드포인트로 Refresh Token 갱신 요청 시도. URI: {}", provider, config.getTokenEndpoint());
-        try {
-            GoogleTokenDto tokenResponse = webClient.post()
-                    .uri(config.getTokenEndpoint())
-                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                    .body(BodyInserters.fromFormData("client_id", config.getClientId())
-                            .with("client_secret", config.getClientSecret())
-                            .with("refresh_token", refreshToken)
-                            .with("grant_type", "refresh_token"))
-                    .retrieve()
-                    .onStatus(status -> status.is4xxClientError() || status.is5xxServerError(), clientResponse -> {
-                    	return clientResponse.bodyToMono(String.class)
-                                .flatMap(body -> {
-                                    log.error("❌ Google Token API 에러 응답 수신. 상태: {}, 바디: {}", 
-                                               clientResponse.statusCode(), body);
-                                    if (body.contains("invalid_grant")) {
-                                        // ⭐ 2. 무효화된 토큰 DB에서 삭제 (비동기 처리)
-                                        userSocialTokenRepository.findByRefreshToken(refreshToken)
-                                                .ifPresent(token -> {
-                                                    log.warn("무효화된 Refresh Token 삭제 (User ID: {}): {}", userId, token.getRefreshToken().subSequence(0, 10));
-                                                    userSocialTokenRepository.delete(token);
-                                                });
-                                    }                              
-                                    
-                                    return Mono.error(new RuntimeException("Google 토큰 갱신 실패. 응답: " + body));
-                                });
-                    })
-                .bodyToMono(GoogleTokenDto.class) // bodyToMono의 인자 변경
-                .block();
-            log.info("API RESPONSE: {} Access Token 갱신 성공. 만료 시간: {}초", provider, tokenResponse.getExpiresIn());
-            if (tokenResponse == null || tokenResponse.getAccessToken() == null) {
-                throw new RuntimeException("Google로부터 유효한 Access Token을 받지 못했습니다.");
-            }     
-            String newAccessToken = tokenResponse.getAccessToken();
-            LocalDateTime expiresAt = LocalDateTime.now().plusSeconds(tokenResponse.getExpiresIn());
-            // DTO에 맞게 로깅 정보 수정            
-            socialToken.setAccessToken(newAccessToken);
-            socialToken.setExpiresAt(expiresAt);
-            userSocialTokenRepository.save(socialToken); //DB 갱신
-            log.info("Access Token 갱신 성공. 만료 시간: {}초", tokenResponse.getExpiresIn());
-            return newAccessToken;
+	 private String refreshAccessToken(String refreshToken, String provider, Long userId, UserSocialToken socialToken) {
+	    	
+	    	GoogleAuthDTO.ProviderConfig config = googleAuthDTO.getProvider()
+	                .get(provider);   	
+	    	
+	        log.info("API CALL: {} 토큰 엔드포인트로 Refresh Token 갱신 요청 시도. URI: {}", provider, config.getTokenEndpoint());
+	        try {
+	            GoogleTokenDto tokenResponse = webClient.post()
+	                    .uri(config.getTokenEndpoint())
+	                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+	                    .body(BodyInserters.fromFormData("client_id", config.getClientId())
+	                            .with("client_secret", config.getClientSecret())
+	                            .with("refresh_token", refreshToken)
+	                            .with("grant_type", "refresh_token"))
+	                    .retrieve()
+	                    .onStatus(status -> status.is4xxClientError() || status.is5xxServerError(), clientResponse -> {
+	                    	return clientResponse.bodyToMono(String.class)
+	                                .flatMap(body -> {
+	                                    log.error("❌ Google Token API 에러 응답 수신. 상태: {}, 바디: {}", 
+	                                               clientResponse.statusCode(), body);
+	                                    if (body.contains("invalid_grant")) {
+	                                        // 무효화된 토큰 DB에서 삭제
+	                                        userSocialTokenRepository.findByRefreshToken(refreshToken)
+	                                                .ifPresent(token -> {
+	                                                    log.warn("무효화된 Refresh Token 삭제 (User ID: {}): {}", userId, token.getRefreshToken().subSequence(0, 10));
+	                                                    userSocialTokenRepository.delete(token);
+	                                                });
+	                                    }                              
+	                                    
+	                                    // [ 4. 수정 ] (500 에러 원인) RuntimeException 대신 GoogleOAuthException 사용 (401 유발)
+	                                    return Mono.error(new GoogleOAuthException("Google 토큰 갱신 실패. 응답: " + body));
+	                                });
+	                    })
+	                .bodyToMono(GoogleTokenDto.class) 
+	                .block(); // WebClient 동기 사용
+	            
+	            log.info("API RESPONSE: {} Access Token 갱신 성공. 만료 시간: {}초", provider, tokenResponse.getExpiresIn());
+	            if (tokenResponse == null || tokenResponse.getAccessToken() == null) {
+	                // [ 5. 수정 ] GoogleOAuthException 사용 (401 유발)
+	                throw new GoogleOAuthException("Google로부터 유효한 Access Token을 받지 못했습니다.");
+	            }     
+	            
+	            String newAccessToken = tokenResponse.getAccessToken();
+	            LocalDateTime expiresAt = LocalDateTime.now().plusSeconds(tokenResponse.getExpiresIn());
+	           
+	            socialToken.setAccessToken(newAccessToken);
+	            socialToken.setExpiresAt(expiresAt);
+	            userSocialTokenRepository.save(socialToken); //DB 갱신
+	            log.info("Access Token 갱신 성공. 만료 시간: {}초", tokenResponse.getExpiresIn());
+	            return newAccessToken;
 
-        } catch (RuntimeException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("Google Access Token 갱신 중 일반 오류 발생", e);
-            throw new RuntimeException("Google Access Token 갱신 중 통신/처리 오류 발생: " + e.getMessage());
-        }
-    }
+	        } catch (GoogleOAuthException e) { // 내가 던진 예외는 그대로 다시 던짐
+	            log.warn("GoogleOAuthException 발생: {}", e.getMessage());
+	            throw e; 
+	        } catch (Exception e) {
+	            log.error("Google Access Token 갱신 중 일반 오류 발생", e);
+	            // [ 6. 수정 ] 그 외 모든 예외도 500 대신 401로 유도 (네트워크 문제 등)
+	            throw new GoogleOAuthException("Google Access Token 갱신 중 통신/처리 오류 발생: " + e.getMessage());
+	        }
+	    }
 	
 }

--- a/src/main/java/com/dialog/user/domain/MeetUser.java
+++ b/src/main/java/com/dialog/user/domain/MeetUser.java
@@ -82,12 +82,12 @@ public class MeetUser {
    private String snsId;
 
     
-    //계정 생성일
+   //계정 생성일
    @CreationTimestamp
    @Column(name = "created_at", nullable = false, updatable = false)
    private LocalDateTime createdAt;
 
-   // 소셜 토큰
+   	// 소셜 토큰
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY,
             cascade = CascadeType.ALL, orphanRemoval = true)
     private List<UserSocialToken> socialTokens = new ArrayList<>();
@@ -106,7 +106,6 @@ public class MeetUser {
     //  JPA를 위한 기본 생성자.
    protected MeetUser() {
    }
-
    
    @Builder
    public MeetUser(String email, String password, String name, String socialType, String snsId, String profileImgUrl, Role role) {


### PR DESCRIPTION
## **구현 기능 요약**

* Google Calendar API 연동 시 발생하는 400(Bad Request) 및 500(Server Error) 오류를 401(Unauthorized)로 통일하는 전역 예외 처리 로직을 구현했습니다.
이를 통해 프론트엔드에서 토큰 만료 또는 미연동 시, 재연동 모달이 정상적으로 표시되도록 백엔드 응답을 안정화했습니다.
---
## **개발 내역 상세**

1. 전역 예외 처리 도입 (GlobalExceptionHandler): 
- @RestControllerAdvice를 활용해 API 전역의 예외를 일괄 처리하는 핸들러를 구현
- 컨트롤러의 try-catch 코드를 모두 제거하여 코드를 간소화하고 유지보수성을 높힘

2. 커스텀 예외 클래스 정의 (GoogleOAuthException):
- GoogleOAuthException(401), ResourceNotFoundException(404) 등 비즈니스 상황에 맞는 예외 클래스를 정의하여, 에러 상황을 명확하게 구분
- 서비스 로직 리팩토링 (SocialTokenService, GoogleCalendarApiClient):

3. SocialTokenService: 
- 토큰이 DB에 없거나(토큰 없음) 갱신에 실패(invalid_grant)했을 때, 기존의 IllegalArgumentException(400) 또는 RuntimeException(500) 대신 GoogleOAuthException(401)을 throw 하도록 수정

4. GoogleCalendarApiClient:
- Google API 호출이 401 에러로 실패했을 때, RuntimeException 대신 GoogleOAuthException을 throw 하도록 수정

5. 예외 변환 로직 보강 (CalendarEventService):

* API 클라이언트에서 발생한 예외를 catch 하여, 에러 메시지에 "401" 또는 "invalid_grant"가 포함된 경우 GoogleOAuthException으로 변환하여 다시 throw 하도록 예외 처리 로직을 강화
---

## **검증 방법**
1. 토큰이 없는 사용자 (신규/카카오 로그인 유저):

* http://localhost:8080/api/calendar/events API 호출 시, 백엔드가 401 상태 코드와 { "errorCode": "GOOGLE_REAUTH_REQUIRED" } JSON을 반환하는지 확인합니다.

* 프론트엔드 home.js에서 401 응답을 받아 구글 연동 모달이 정상적으로 팝업되는지 확인합니다.

2. 토큰이 만료된 사용자 (기존 연동 유저):

* (테스트 방법: Google 계정 설정에서 앱 접근 권한을 수동으로 삭제하여 invalid_grant 유도)

* http://localhost:8080/api/calendar/events API 호출 시, 백엔드가 500 에러 대신 401 상태 코드와 { "errorCode": "GOOGLE_REAUTH_REQUIRED" } JSON을 반환하는지 확인

3. 일반 404/400 오류:

* toggleImportance 등에서 존재하지 않는 ID로 요청 시 404 응답이 오는지 확인

* createEvent에서 body 없이 요청 시 400 응답이 오는지 확인
---
