### PR TITLE
feat: [BE] STT 실시간 스트리밍 서버와 회의 페이지 연결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,8 +47,14 @@ dependencies {
     implementation 'com.google.api-client:google-api-client:1.33.0' 
 	implementation 'com.google.oauth-client:google-oauth-client-jetty:1.33.0' 
 	implementation 'com.google.http-client:google-http-client-jackson2:1.39.2' 
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.13.4' 
+    // implementation 'com.fasterxml.jackson.core:jackson-core:2.13.4' 
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	
+	// Jackson 버전 업그레이드 (2.13.4 → 2.17.2)
+	// recoding 엔티티 저장 과정에서 호환된 jackson 버전 필요로 수정
+	implementation 'com.fasterxml.jackson.core:jackson-core:2.17.2'
+	implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.2'
+	implementation 'com.fasterxml.jackson.core:jackson-annotations:2.17.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dialog/meeting/controller/MeetingController.java
+++ b/src/main/java/com/dialog/meeting/controller/MeetingController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.dialog.meeting.domain.Meeting;
 import com.dialog.meeting.domain.MeetingCreateRequestDto;
 import com.dialog.meeting.domain.MeetingCreateResponseDto;
+import com.dialog.meeting.domain.MeetingFinishRequestDto;
 import com.dialog.meeting.service.MeetingService;
 
 import com.dialog.security.jwt.JwtAuthenticationFilter;
@@ -24,69 +25,88 @@ import com.dialog.user.service.UserDetailsServiceImpl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-
 @Slf4j
-@RestController 
+@RestController
 @RequestMapping("/api/meetings")
-@RequiredArgsConstructor 
+@RequiredArgsConstructor
 public class MeetingController {
 
-    private final MeetingService meetingService; 
+	private final MeetingService meetingService;
 
-    // 새 회의 생성
-    @PostMapping
-    public ResponseEntity<MeetingCreateResponseDto> createMeeting(
-            @RequestBody MeetingCreateRequestDto requestDto,
-            Authentication authentication
-    ) throws IllegalAccessException {
+	// 새 회의 생성
+	@PostMapping
+	public ResponseEntity<MeetingCreateResponseDto> createMeeting(@RequestBody MeetingCreateRequestDto requestDto,
+			Authentication authentication) throws IllegalAccessException {
 
-        // 인증 정보가 없으면 401 Unauthorized 반환
-        if (authentication == null) {
-            log.warn("인증 정보 없음 - 인증되지 않은 요청");
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        }
+		// 인증 정보가 없으면 401 Unauthorized 반환
+		if (authentication == null) {
+			log.warn("인증 정보 없음 - 인증되지 않은 요청");
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+		}
 
-        Object principal = authentication.getPrincipal(); // 인증된 사용자 주체 객체
-        Long currentHostUserId; // 현재 회의 호스트(생성자) ID
+		Object principal = authentication.getPrincipal(); // 인증된 사용자 주체 객체
+		Long currentHostUserId; // 현재 회의 호스트(생성자) ID
 
-        // 인증 주체(principal) 타입별로 사용자 ID 추출 (소셜/일반 가입 모두 처리)
-        if (principal instanceof CustomOAuth2User) {
-            currentHostUserId = ((CustomOAuth2User) principal).getMeetuser().getId();
-        } else if (principal instanceof CustomUserDetails) {
-            CustomUserDetails userDetails = (CustomUserDetails) principal;
-            currentHostUserId = userDetails.getId();
-        } else if (principal instanceof UserDetails) {
-            // UserDetails 기본 구현체(일반 사용)는 CustomUserDetails가 아니라면 거부
-            log.warn("인증 객체가 CustomUserDetails가 아님: {}", principal.getClass());
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        } else {
-            log.warn("알 수 없는 인증 객체 타입: {}", principal.getClass());
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        }
+		// 인증 주체(principal) 타입별로 사용자 ID 추출 (소셜/일반 가입 모두 처리)
+		if (principal instanceof CustomOAuth2User) {
+			currentHostUserId = ((CustomOAuth2User) principal).getMeetuser().getId();
+		} else if (principal instanceof CustomUserDetails) {
+			CustomUserDetails userDetails = (CustomUserDetails) principal;
+			currentHostUserId = userDetails.getId();
+		} else if (principal instanceof UserDetails) {
+			// UserDetails 기본 구현체(일반 사용)는 CustomUserDetails가 아니라면 거부
+			log.warn("인증 객체가 CustomUserDetails가 아님: {}", principal.getClass());
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+		} else {
+			log.warn("알 수 없는 인증 객체 타입: {}", principal.getClass());
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+		}
 
-        // 서비스 계층에 회의 생성 요청 (요청 데이터와 호스트 ID 전달)
-        MeetingCreateResponseDto responseDto = meetingService.createMeeting(requestDto, currentHostUserId);
+		// 서비스 계층에 회의 생성 요청 (요청 데이터와 호스트 ID 전달)
+		MeetingCreateResponseDto responseDto = meetingService.createMeeting(requestDto, currentHostUserId);
 
-        // 생성된 회의 정보를 담은 DTO와 201(CREATED) 상태로 응답
-        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
-    }
-    
+		// 생성된 회의 정보를 담은 DTO와 201(CREATED) 상태로 응답
+		return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+	}
+
 	// 특정 회의 상세 조회 엔드포인트
 	@GetMapping("/{meetingId}")
 	public ResponseEntity<MeetingCreateResponseDto> getMeeting(@PathVariable("meetingId") Long meetingId) {
-	    try {
-	        // 서비스에서 ID로 회의 엔티티 조회
-	    	MeetingCreateResponseDto responseDto = meetingService.findById(meetingId);
-	        // 회의를 찾을 수 없는 경우 404 반환
-	        if (responseDto == null) {
-	            return ResponseEntity.notFound().build();
-	        }
-	        // Meeting 엔티티를 DTO로 변환해 반환 
-	        return ResponseEntity.ok(responseDto);
-	    } catch (Exception e) {
-	        // 예외 발생 시 500 에러 반환 (서버 로그 기록)
-	    	log.error("Meeting 조회 중 예외 발생", e);
-	        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-	    }
+		try {
+			// 서비스에서 ID로 회의 엔티티 조회
+			MeetingCreateResponseDto responseDto = meetingService.findById(meetingId);
+			// 회의를 찾을 수 없는 경우 404 반환
+			if (responseDto == null) {
+				return ResponseEntity.notFound().build();
+			}
+			// Meeting 엔티티를 DTO로 변환해 반환
+			return ResponseEntity.ok(responseDto);
+		} catch (Exception e) {
+			// 예외 발생 시 500 에러 반환 (서버 로그 기록)
+			log.error("Meeting 조회 중 예외 발생", e);
+			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+		}
+	}
+
+	@PostMapping("/{meetingId}/finish")
+	public ResponseEntity<?> finishMeeting(@PathVariable("meetingId") Long meetingId,
+			@RequestBody MeetingFinishRequestDto requestDto) {
+		try {
+			log.info("회의 종료 요청 - meetingId: {}", meetingId);
+
+			// 서비스에서 회의 종료 처리
+			meetingService.finishMeeting(meetingId, requestDto);
+
+			log.info("회의 종료 완료 - meetingId: {}", meetingId);
+			return ResponseEntity.ok().build();
+
+		} catch (IllegalArgumentException e) {
+			log.error("회의 종료 실패 - 회의를 찾을 수 없음: {}", e.getMessage());
+			return ResponseEntity.status(HttpStatus.NOT_FOUND).body("회의를 찾을 수 없습니다: " + e.getMessage());
+		} catch (Exception e) {
+			log.error("회의 종료 중 예외 발생", e);
+			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+					.body("회의 종료 중 오류가 발생했습니다: " + e.getMessage());
+		}
 	}
 }

--- a/src/main/java/com/dialog/meeting/domain/Meeting.java
+++ b/src/main/java/com/dialog/meeting/domain/Meeting.java
@@ -9,8 +9,10 @@ import org.hibernate.annotations.UpdateTimestamp;
 
 import com.dialog.keyword.domain.Keyword;
 import com.dialog.participant.domain.Participant;
+import com.dialog.recording.domain.Recording;
 import com.dialog.user.domain.MeetUser;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -25,6 +27,7 @@ import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -81,7 +84,11 @@ public class Meeting {
 
 	@OneToMany(mappedBy = "meeting", fetch = FetchType.LAZY)
 	private List<Participant> participants;
-
+	
+	// Meeting.java에 추가
+	@OneToOne(mappedBy = "meeting", cascade = CascadeType.ALL, orphanRemoval = true)
+	private Recording recording;
+	
 	// 키워드 연관관계 (다대다)
 	@Builder.Default
 	@ManyToMany

--- a/src/main/java/com/dialog/meeting/domain/MeetingFinishRequestDto.java
+++ b/src/main/java/com/dialog/meeting/domain/MeetingFinishRequestDto.java
@@ -1,0 +1,38 @@
+package com.dialog.meeting.domain;
+
+//import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class MeetingFinishRequestDto {
+    
+    private Integer duration;  // 회의 진행 시간 (초)
+    private String endTime;    // 종료 시간 (ISO format)
+//    private List<TranscriptDto> transcripts;  // 대화 내용
+    private Integer sentenceCount;  // 문장 수
+    private Double avgConfidence;  // 평균 신뢰도
+    private RecordingData recording;  // 녹음 파일 정보
+    
+//    @Getter
+//    @Setter
+//    @NoArgsConstructor
+//    public static class TranscriptDto {
+//        private String speaker;  // 발화자
+//        private String time;     // 시간
+//        private String text;     // 내용
+//    }
+    
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class RecordingData {
+        private String audioFileUrl;      // 오디오 파일 URL
+        private String audioFormat;       // 오디오 형식 (wav, mp3 등)
+        private Long audioFileSize;       // 파일 크기 (bytes)
+        private Integer durationSeconds;  // 녹음 길이 (초)
+    }
+}

--- a/src/main/java/com/dialog/recording/controller/RecordingController.java
+++ b/src/main/java/com/dialog/recording/controller/RecordingController.java
@@ -1,0 +1,96 @@
+package com.dialog.recording.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.dialog.recording.domain.RecordingCreateRequestDto;
+import com.dialog.recording.domain.RecordingResponseDto;
+import com.dialog.recording.domain.RecordingUpdateRequestDto;
+import com.dialog.recording.service.RecordingService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/recordings")
+@RequiredArgsConstructor
+public class RecordingController {
+
+	private final RecordingService recordingService;
+
+	// 녹음 파일 정보 저장 (Meeting과 연결) POST /api/recordings?meetingId=1
+	@PostMapping
+	public ResponseEntity<RecordingResponseDto> createRecording(
+			@RequestParam("meetingId") Long meetingId,
+			@RequestBody RecordingCreateRequestDto requestDto) {
+		try {
+			RecordingResponseDto response = recordingService.saveRecording(meetingId, requestDto);
+			return ResponseEntity.status(HttpStatus.CREATED).body(response);
+		} catch (IllegalArgumentException e) {
+			log.error("Recording 생성 실패: {}", e.getMessage());
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+		} catch (IllegalStateException e) {
+			log.error("Recording 중복: {}", e.getMessage());
+			return ResponseEntity.status(HttpStatus.CONFLICT).build();
+		}
+	}
+
+	// Meeting ID로 녹음 조회 GET /api/recordings/meeting/1
+	@GetMapping("/meeting/{meetingId}")
+	public ResponseEntity<RecordingResponseDto> getRecordingByMeeting(@PathVariable("meetingId") Long meetingId) {
+		try {
+			RecordingResponseDto response = recordingService.getRecordingByMeetingId(meetingId);
+			return ResponseEntity.ok(response);
+		} catch (IllegalArgumentException e) {
+			log.error("Recording 조회 실패: {}", e.getMessage());
+			return ResponseEntity.notFound().build();
+		}
+	}
+
+	// Recording ID로 녹음 조회 GET /api/recordings/1
+	@GetMapping("/{recordingId}")
+	public ResponseEntity<RecordingResponseDto> getRecording(@PathVariable("recordingId") Long recordingId) {
+		try {
+			RecordingResponseDto response = recordingService.getRecordingById(recordingId);
+			return ResponseEntity.ok(response);
+		} catch (IllegalArgumentException e) {
+			log.error("Recording 조회 실패: {}", e.getMessage());
+			return ResponseEntity.notFound().build();
+		}
+	}
+
+	// 녹음 파일 정보 업데이트 PUT /api/recordings/1
+	@PutMapping("/{recordingId}")
+	public ResponseEntity<RecordingResponseDto> updateRecording(@PathVariable("recordingId") Long recordingId,
+			@RequestBody RecordingUpdateRequestDto requestDto) {
+		try {
+			RecordingResponseDto response = recordingService.updateRecording(recordingId, requestDto);
+			return ResponseEntity.ok(response);
+		} catch (IllegalArgumentException e) {
+			log.error("Recording 업데이트 실패: {}", e.getMessage());
+			return ResponseEntity.notFound().build();
+		}
+	}
+
+	// 녹음 삭제 DELETE /api/recordings/1
+	@DeleteMapping("/{recordingId}")
+	public ResponseEntity<Void> deleteRecording(@PathVariable("recordingId") Long recordingId) {
+		try {
+			recordingService.deleteRecording(recordingId);
+			return ResponseEntity.noContent().build();
+		} catch (IllegalArgumentException e) {
+			log.error("Recording 삭제 실패: {}", e.getMessage());
+			return ResponseEntity.notFound().build();
+		}
+	}
+}

--- a/src/main/java/com/dialog/recording/domain/Recording.java
+++ b/src/main/java/com/dialog/recording/domain/Recording.java
@@ -1,0 +1,77 @@
+package com.dialog.recording.domain;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import com.dialog.meeting.domain.Meeting;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "recording")
+@Getter 
+@NoArgsConstructor(access = AccessLevel.PROTECTED) 
+@AllArgsConstructor 
+@Builder(toBuilder = true) 
+public class Recording {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "meeting_id", nullable = false, unique = true)
+    private Meeting meeting;
+    
+    @Column(name = "audio_file_url", length = 1000)
+    private String audioFileUrl;
+    
+    @Column(name = "audio_file_size")
+    private Long audioFileSize;
+    
+    @Column(name = "audio_format", length = 20)
+    private String audioFormat;
+    
+    @Column(name = "duration_seconds")
+    private Integer durationSeconds;
+    
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+    
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    /** 녹음파일 저장 시 호출 */
+    public void saveAudioFile(String url, Long fileSize, String format, Integer duration) {
+        this.audioFileUrl = url;
+        this.audioFileSize = fileSize;
+        this.audioFormat = format;
+        this.durationSeconds = duration;
+    }
+
+    /** 업로드 완료 처리 (null 허용) */
+    public void completeUpload(String url, Long fileSize, String format, Integer duration) {
+        if (url != null && !url.isBlank()) {
+            this.audioFileUrl = url;
+        }
+        if (fileSize != null) {
+            this.audioFileSize = fileSize;
+        }
+        if (format != null) {
+            this.audioFormat = format;
+        }
+        if (duration != null) {
+            this.durationSeconds = duration;
+        }
+    }
+
+    /** 오디오 파일 존재 여부 */
+    public boolean hasAudioFile() {
+        return this.audioFileUrl != null && !this.audioFileUrl.isBlank();
+    }
+}

--- a/src/main/java/com/dialog/recording/domain/RecordingCreateRequestDto.java
+++ b/src/main/java/com/dialog/recording/domain/RecordingCreateRequestDto.java
@@ -1,0 +1,21 @@
+package com.dialog.recording.domain;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class RecordingCreateRequestDto {
+
+    @NotBlank(message = "오디오 파일 URL은 필수입니다.")
+    private String audioFileUrl;
+
+    private Long audioFileSize;
+
+    private String audioFormat;
+
+    private Integer durationSeconds;
+}

--- a/src/main/java/com/dialog/recording/domain/RecordingResponseDto.java
+++ b/src/main/java/com/dialog/recording/domain/RecordingResponseDto.java
@@ -1,0 +1,37 @@
+package com.dialog.recording.domain;
+
+import java.time.LocalDateTime;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class RecordingResponseDto {
+
+	private Long recordingId;
+	private Long meetingId;
+	private String audioFileUrl;
+	private Long audioFileSize;
+	private String audioFormat;
+	private Integer durationSeconds;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+
+	public RecordingResponseDto(Recording recording) {
+		this.recordingId = recording.getId();
+
+		if (recording.getMeeting() != null) {
+			this.meetingId = recording.getMeeting().getId();
+		}
+
+		this.audioFileUrl = recording.getAudioFileUrl();
+		this.audioFileSize = recording.getAudioFileSize();
+		this.audioFormat = recording.getAudioFormat();
+		this.durationSeconds = recording.getDurationSeconds();
+		this.createdAt = recording.getCreatedAt();
+		this.updatedAt = recording.getUpdatedAt();
+	}
+}

--- a/src/main/java/com/dialog/recording/domain/RecordingUpdateRequestDto.java
+++ b/src/main/java/com/dialog/recording/domain/RecordingUpdateRequestDto.java
@@ -1,0 +1,16 @@
+package com.dialog.recording.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class RecordingUpdateRequestDto {
+
+    private String audioFileUrl;
+    private Long audioFileSize;
+    private String audioFormat;
+    private Integer durationSeconds;
+}

--- a/src/main/java/com/dialog/recording/repository/RecordingRepository.java
+++ b/src/main/java/com/dialog/recording/repository/RecordingRepository.java
@@ -1,0 +1,22 @@
+package com.dialog.recording.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.dialog.recording.domain.Recording;
+
+public interface RecordingRepository extends JpaRepository<Recording, Long> {
+
+	// Meeting ID로 Recording 조회
+    Optional<Recording> findByMeetingId(Long meetingId);
+    
+	// Meeting ID로 Recording 존재 여부 확인
+    boolean existsByMeetingId(Long meetingId);
+    
+	// Audio File URL로 Recording 조회
+    Optional<Recording> findByAudioFileUrl(String audioFileUrl);
+    
+	// Meeting ID로 Recording 삭제
+    void deleteByMeetingId(Long meetingId);
+}

--- a/src/main/java/com/dialog/recording/service/RecordingService.java
+++ b/src/main/java/com/dialog/recording/service/RecordingService.java
@@ -1,0 +1,94 @@
+package com.dialog.recording.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.dialog.meeting.domain.Meeting;
+import com.dialog.meeting.repository.MeetingRepository;
+import com.dialog.recording.domain.Recording;
+import com.dialog.recording.domain.RecordingCreateRequestDto;
+import com.dialog.recording.domain.RecordingResponseDto;
+import com.dialog.recording.domain.RecordingUpdateRequestDto;
+import com.dialog.recording.repository.RecordingRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RecordingService {
+
+    private final RecordingRepository recordingRepository;
+    private final MeetingRepository meetingRepository;
+
+    // 녹음 파일 정보 저장 (Meeting과 연결)
+    @Transactional
+    public RecordingResponseDto saveRecording(Long meetingId, RecordingCreateRequestDto requestDto) {
+        // 1. Meeting 조회
+        Meeting meeting = meetingRepository.findById(meetingId)
+            .orElseThrow(() -> new IllegalArgumentException("회의를 찾을 수 없습니다."));
+
+        // 2. 이미 녹음이 존재하는지 확인
+        if (recordingRepository.existsByMeetingId(meetingId)) {
+            throw new IllegalStateException("이미 녹음 파일이 존재합니다.");
+        }
+
+        // 3. Recording 엔티티 생성
+        Recording recording = Recording.builder()
+            .meeting(meeting)
+            .audioFileUrl(requestDto.getAudioFileUrl())
+            .audioFileSize(requestDto.getAudioFileSize())
+            .audioFormat(requestDto.getAudioFormat())
+            .durationSeconds(requestDto.getDurationSeconds())
+            .build();
+
+        // 4. 저장
+        Recording savedRecording = recordingRepository.save(recording);
+
+        // 5. Meeting 상태를 COMPLETED로 변경
+        meeting.complete();
+
+        return new RecordingResponseDto(savedRecording);
+    }
+
+    // Meeting ID로 녹음 조회
+    public RecordingResponseDto getRecordingByMeetingId(Long meetingId) {
+        Recording recording = recordingRepository.findByMeetingId(meetingId)
+            .orElseThrow(() -> new IllegalArgumentException("녹음 파일을 찾을 수 없습니다."));
+
+        return new RecordingResponseDto(recording);
+    }
+
+    // Recording ID로 녹음 조회
+    public RecordingResponseDto getRecordingById(Long recordingId) {
+        Recording recording = recordingRepository.findById(recordingId)
+            .orElseThrow(() -> new IllegalArgumentException("녹음 파일을 찾을 수 없습니다."));
+
+        return new RecordingResponseDto(recording);
+    }
+
+    // 녹음 파일 정보 업데이트
+    @Transactional
+    public RecordingResponseDto updateRecording(Long recordingId, RecordingUpdateRequestDto requestDto) {
+        Recording recording = recordingRepository.findById(recordingId)
+            .orElseThrow(() -> new IllegalArgumentException("녹음 파일을 찾을 수 없습니다."));
+
+        recording.completeUpload(
+            requestDto.getAudioFileUrl(),
+            requestDto.getAudioFileSize(),
+            requestDto.getAudioFormat(),
+            requestDto.getDurationSeconds()
+        );
+
+        return new RecordingResponseDto(recording);
+    }
+
+    // 녹음 삭제
+    @Transactional
+    public void deleteRecording(Long recordingId) {
+        Recording recording = recordingRepository.findById(recordingId)
+            .orElseThrow(() -> new IllegalArgumentException("녹음 파일을 찾을 수 없습니다."));
+
+        recordingRepository.delete(recording);
+    }
+}


### PR DESCRIPTION
## **구현 기능 요약**

-  Recording 도메인 신규 추가 및 CRUD 계층(Service, Repository, DTO, Entity) 구현
- Meeting 엔티티에 회의 종료(complete()), 정보 수정(updateInfo()) 등 비즈니스 로직 추가
- FastAPI STT 서버에서 업로드되는 Object Storage URL, STT 텍스트를 Spring Recording 엔티티에 반영할 수 있도록 구조 설계
- 프론트엔드(recording.js)의 회의 종료 시점에서 /finish API 호출 로직과의 연동 준비 완료

---

## **개발 내역 상세**
Recording.java
- 녹음 파일 URL(audio_file_url), 로컬 경로(local_file_path), STT 원문(stt_raw_text), 언어 코드(language_code) 필드 추가
- Meeting과의 외래키(meeting_id) 설정 및 @OneToOne 매핑

RecordingService.java / RecordingRepository.java
- createRecording, updateRecording, findByMeetingId 등 비즈니스 로직 구현
- Meeting 존재 여부 검증 및 예외 처리 (EntityNotFoundException, IllegalStateException)

DTO (RecordingCreateRequestDto / RecordingUpdateRequestDto / RecordingResponseDto)
- 요청·응답 객체 분리 및 유효성 검증 구조 구성

Meeting.java / MeetingService.java / MeetingController.java
- complete(), updateInfo() 로직 및 회의 상태 전이 (SCHEDULED → RECORDING → COMPLETED) 추가
- 회의 종료 시 Recording 생성 트리거 연결 준비

---

## **검증 방법**

1. Meeting 생성 → Recording 생성

- /api/meetings/{id}/recordings POST 요청으로 신규 녹음 정보 등록
- DB에 Recording 레코드 생성 및 Meeting과 1:1 매핑 확인

2. 회의 종료 처리

- /api/meetings/{id}/finish 호출 시, Meeting 상태가 COMPLETED로 변경되고 관련 Recording 조회 가능

3. 데이터 검증

- MySQL 콘솔 또는 Workbench에서 recording 테이블의 audio_file_url, stt_raw_text 값 확인
- Object Storage URL이 정상적으로 반환되는지 확인

4. 프론트엔드 연동 테스트

- recording.js 실행 후 회의 종료 시 API 호출 로그(finish) 확인
- FastAPI 로그에서 Object Storage 업로드 및 CLOVA 분석 로그 정상 출력 확인

---

## **추가 개선 / TODO**

- FastAPI에서 반환하는 file_url을 Spring RecordingService로 전달하여 자동 저장
- CLOVA 비동기 분석 결과(speakerStats, segments)를 Transcript 테이블에 매핑Recording 삭제 시 Object Storage의 음성 파일도 함께 제거하는 로직 추가
- recordFinish.html과 RecordingResponseDto 연동을 통한 요약·하이라이트 출력 구현 STT 처리 중 실시간 로그(WebSocket → 프론트 전송) 기능 고도화
