### PR TITLE
feat: [BE] 일정관리페이지 '중요 표시' 기능 구현 및 메인 페이지 연동

### DIFF
--- a/src/main/java/com/dialog/GlobalExceptionHandler.java
+++ b/src/main/java/com/dialog/GlobalExceptionHandler.java
@@ -6,7 +6,7 @@ import java.util.Map;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-
+import org.springframework.security.authentication.DisabledException;
 import com.dialog.exception.GoogleOAuthException;
 import com.dialog.exception.GoogleOAuthException.AccessDeniedException;
 import com.dialog.exception.GoogleOAuthException.ResourceNotFoundException;
@@ -52,6 +52,17 @@ public class GlobalExceptionHandler {
          log.warn(" Access Denied: {}", e.getMessage());
          return ResponseEntity.status(HttpStatus.FORBIDDEN)
                  .body(Map.of("error", "Forbidden", "message", e.getMessage()));
+    }
+    // 비활성화시 발생되는 예외처리.
+    @ExceptionHandler(DisabledException.class)
+    public ResponseEntity<Map<String, String>> handleDisabledException(DisabledException e) {
+        log.warn("❌ 비활성화된 계정 접근 시도: {}", e.getMessage());
+        Map<String, String> responseBody = Map.of(
+            "status", "401",
+            "error", "Unauthorized",
+            "message", e.getMessage() // "계정이 비활성화되었습니다. 관리자에게 문의하세요."
+        );        
+        return new ResponseEntity<>(responseBody, HttpStatus.UNAUTHORIZED);
     }
     
     // 4. 잘못된 요청 (400) - 기존 로직 유지하되 더 깔끔하게

--- a/src/main/java/com/dialog/calendarevent/controller/CalendarEventController.java
+++ b/src/main/java/com/dialog/calendarevent/controller/CalendarEventController.java
@@ -113,10 +113,21 @@ public class CalendarEventController {
 		return ResponseEntity.ok().build();
 	}
 
-	// 캘린더 중요도 표시 하는 API
-	@PatchMapping("/{eventId}/importance")
-	public ResponseEntity<Void> toggleImportance(@PathVariable Long eventId) { 
-		calendarEventService.toggleImportance(eventId);
-		return ResponseEntity.ok().build();
-	}
+	@PatchMapping("/calendar/{eventId}/importance")
+    public ResponseEntity<Void> toggleImportance(
+            @PathVariable("eventId") String eventId,
+            Principal principal) {
+
+        if (principal == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        
+        // 현재 로그인한 사용자 이메일
+        String userEmail = principal.getName();
+
+        // [중요] 서비스 계층에도 userEmail과 eventId를 전달합니다.
+        calendarEventService.toggleImportance(userEmail, eventId);
+
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/dialog/calendarevent/domain/CalendarEventResponse.java
+++ b/src/main/java/com/dialog/calendarevent/domain/CalendarEventResponse.java
@@ -1,28 +1,38 @@
 package com.dialog.calendarevent.domain;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 @Getter
-@Builder // DTO 생성을 쉽게 하기 위해 Builder 패턴 사용
+@Setter
+@Builder
+@NoArgsConstructor 
+@AllArgsConstructor 
 public class CalendarEventResponse {
 
-	private final Long id;
-	private final Long userId;
-	private final String title;
+	private Long id; // final 제거 확인됨 (Good!)
+	private Long userId;
+	private String title;
 
-	private final String eventDate;
+	private String eventDate;
 
-	private final LocalTime time;
-	private final String eventType;
-
-	private final boolean isImportant;
-	private final String sourceId;
-	private final String googleEventId;
-	private final LocalDateTime createdAt;
+	private LocalTime time;
+	private String eventType;
+	
+	@JsonProperty("isImportant")
+	private boolean isImportant;
+	private String sourceId;
+	private String googleEventId;
+	private LocalDateTime createdAt;
 
 	public static CalendarEventResponse from(CalendarEvent entity) {
 		if (entity == null) {

--- a/src/main/java/com/dialog/calendarevent/service/CalendarEventService.java
+++ b/src/main/java/com/dialog/calendarevent/service/CalendarEventService.java
@@ -2,7 +2,10 @@ package com.dialog.calendarevent.service;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,50 +34,73 @@ public class CalendarEventService {
 	private final GoogleCalendarApiClient googleCalendarApiClient;
 	private final MeetUserRepository meetUserRepository;
 
-public List<CalendarEventResponse> getEventsByDateRange(String userEmail, LocalDate startDate, LocalDate endDate) {
-        
-        // 1. IllegalAccessException 대신 ResourceNotFoundException을 throw
-        MeetUser meetUser = meetUserRepository.findByEmail(userEmail)
-                .orElseThrow(() -> new ResourceNotFoundException("MeetUser를 찾을 수 없습니다: " + userEmail));
+	public List<CalendarEventResponse> getEventsByDateRange(String userEmail, LocalDate startDate, LocalDate endDate) {
 
-        Long userId = meetUser.getId();
-        String accessToken = tokenManagerService.getToken(userEmail, "google");
+		MeetUser meetUser = meetUserRepository.findByEmail(userEmail)
+				.orElseThrow(() -> new ResourceNotFoundException("MeetUser를 찾을 수 없습니다: " + userEmail));
 
-        if (accessToken == null || accessToken.isEmpty()) {
-            log.error("Google Access Token이 유효하지 않거나 비어있습니다. 로컬 이벤트만 조회합니다.");
-            return calendarEventRepository.findByUserIdAndEventDateBetween(userId, startDate, endDate).stream()
-                    .map(CalendarEventResponse::from).collect(Collectors.toList());
-        }
+		Long userId = meetUser.getId();
+		String accessToken = tokenManagerService.getToken(userEmail, "google");
 
-        try {
-            // 3. Google Calendar API 조회
-            List<CalendarEventResponse> googleEvents = googleCalendarApiClient.getEvents(accessToken, "primary",
-                    startDate.atStartOfDay(), endDate.plusDays(1).atStartOfDay());
+		// 1. 로컬 DB 이벤트 조회
+		List<CalendarEvent> localEvents = calendarEventRepository.findByUserIdAndEventDateBetween(userId, startDate,
+				endDate);
 
-            List<CalendarEvent> localEvents = calendarEventRepository.findByUserIdAndEventDateBetween(userId, startDate, endDate);
+		Map<String, CalendarEvent> localEventMap = localEvents.stream().filter(e -> e.getGoogleEventId() != null)
+				.collect(Collectors.toMap(CalendarEvent::getGoogleEventId, e -> e, (p1, p2) -> p1));
 
-            // 5. 결과 통합
-            List<CalendarEventResponse> allEvents = localEvents.stream().map(CalendarEventResponse::from)
-                    .collect(Collectors.toList());
-            allEvents.addAll(googleEvents);
+		if (accessToken == null || accessToken.isEmpty()) {
+			return localEvents.stream().map(CalendarEventResponse::from).collect(Collectors.toList());
+		}
 
-            return allEvents;
+		try {
+			List<CalendarEventResponse> googleEvents = googleCalendarApiClient.getEvents(accessToken, "primary",
+					startDate.atStartOfDay(), endDate.plusDays(1).atStartOfDay());
 
-        } catch (Exception e) {           
-        	String errorMessage = (e.getMessage() != null) ? e.getMessage() : "";
+			for (CalendarEventResponse gEvent : googleEvents) {
+				String googleId = gEvent.getGoogleEventId();
 
-            // [수정됨] 401 에러도 GoogleOAuthException으로 처리하도록 조건 추가
-            if (errorMessage.contains("invalid_grant") || 
-                errorMessage.contains("토큰 갱신 실패") || 
-                errorMessage.contains("401")) {
-                throw new GoogleOAuthException("Google 토큰이 만료되었거나 무효화되었습니다. 재연동이 필요합니다.");
-            }
+				// 로컬 DB에 동일한 구글 ID를 가진 데이터가 있는지 확인
+				if (googleId != null && localEventMap.containsKey(googleId)) {
+					CalendarEvent localMatch = localEventMap.get(googleId);
 
-            // 8. 그 외 모든 구글 API 관련 오류
-            log.error("Google Calendar API 조회 중 심각한 오류 발생", e);
-            throw new RuntimeException("Google Calendar API 조회 중 오류가 발생했습니다.", e);
-        }
-    }
+					// 중요도 덮어쓰기 (별표 유지)
+					gEvent.setImportant(localMatch.isImportant());
+
+					if (localMatch.getEventType() != null) {
+						gEvent.setEventType(localMatch.getEventType().name());
+					}
+
+					gEvent.setId(localMatch.getId());
+
+					localEventMap.remove(googleId);
+				}
+			}
+			List<CalendarEventResponse> finalEvents = new ArrayList<>(googleEvents);
+
+			List<CalendarEventResponse> onlyLocalEvents = localEvents.stream().filter(e -> e.getGoogleEventId() == null) // 구글
+																															// ID
+																															// 없는
+																															// 것만
+					.map(CalendarEventResponse::from).collect(Collectors.toList());
+
+			finalEvents.addAll(onlyLocalEvents);
+
+			return finalEvents;
+
+		} catch (Exception e) {
+			String errorMessage = (e.getMessage() != null) ? e.getMessage() : "";
+
+			if (errorMessage.contains("invalid_grant") || errorMessage.contains("토큰 갱신 실패")
+					|| errorMessage.contains("401")) {
+				throw new GoogleOAuthException("Google 토큰이 만료되었거나 무효화되었습니다. 재연동이 필요합니다.");
+			}
+
+			// 8. 그 외 모든 구글 API 관련 오류
+			log.error("Google Calendar API 조회 중 심각한 오류 발생", e);
+			throw new RuntimeException("Google Calendar API 조회 중 오류가 발생했습니다.", e);
+		}
+	}
 
 	@Transactional // DB 쓰기를 위해 (readOnly = true) 덮어쓰기
 	public GoogleEventResponseDTO createCalendarEvent(String principalName, String provider, String calendarId,
@@ -106,68 +132,93 @@ public List<CalendarEventResponse> getEventsByDateRange(String userEmail, LocalD
 
 	@Transactional
 	public GoogleEventResponseDTO updateCalendarEvent(String userEmail, String provider, String calendarId,
-            String eventId, GoogleEventRequestDTO eventData) {
+			String eventId, GoogleEventRequestDTO eventData) {
 
-        String accessToken = tokenManagerService.getToken(userEmail, provider);
-        if (accessToken == null || accessToken.isEmpty()) {
-            // 2. 커스텀 예외로 변경
-            throw new GoogleOAuthException("Google Access Token이 유효하지 않거나 비어있습니다.");
-        }
+		String accessToken = tokenManagerService.getToken(userEmail, provider);
+		if (accessToken == null || accessToken.isEmpty()) {
+			// 2. 커스텀 예외로 변경
+			throw new GoogleOAuthException("Google Access Token이 유효하지 않거나 비어있습니다.");
+		}
 
-        GoogleEventResponseDTO responseFromGoogle;
-        try {
-            responseFromGoogle = googleCalendarApiClient.patchEvent(accessToken, calendarId, eventId, eventData);
-        } catch (Exception e) {
-            if (e.getMessage() != null && e.getMessage().contains("invalid_grant")) {
-                throw new GoogleOAuthException("Google 토큰이 만료되었습니다. 재연동이 필요합니다.");
-            }
-            throw new RuntimeException("Google 캘린더 업데이트 실패", e);
-        }
+		GoogleEventResponseDTO responseFromGoogle;
+		try {
+			responseFromGoogle = googleCalendarApiClient.patchEvent(accessToken, calendarId, eventId, eventData);
+		} catch (Exception e) {
+			if (e.getMessage() != null && e.getMessage().contains("invalid_grant")) {
+				throw new GoogleOAuthException("Google 토큰이 만료되었습니다. 재연동이 필요합니다.");
+			}
+			throw new RuntimeException("Google 캘린더 업데이트 실패", e);
+		}
 
-        // 3. 로컬 DB 업데이트
-        MeetUser user = meetUserRepository.findByEmail(userEmail)
-                .orElseThrow(() -> new ResourceNotFoundException("사용자를 찾을 수 없습니다: " + userEmail));
+		// 3. 로컬 DB 업데이트
+		MeetUser user = meetUserRepository.findByEmail(userEmail)
+				.orElseThrow(() -> new ResourceNotFoundException("사용자를 찾을 수 없습니다: " + userEmail));
 
-        CalendarEvent localEvent = calendarEventRepository.findByGoogleEventIdAndUserId(eventId, user.getId())
-                .orElseThrow(() -> new ResourceNotFoundException("로컬 이벤트를 찾을 수 없습니다: " + eventId));
+		CalendarEvent localEvent = calendarEventRepository.findByGoogleEventIdAndUserId(eventId, user.getId())
+				.orElseThrow(() -> new ResourceNotFoundException("로컬 이벤트를 찾을 수 없습니다: " + eventId));
 
-        try {
-             localEvent.updateEventDetails(eventData.getSummary(), LocalDate.parse(eventData.getStart().getDate()), localEvent.getEventTime(), localEvent.getEventType());
-        } catch (Exception e) {
-            log.error("로컬 DB 동기화 오류", e);
-        }
-        return responseFromGoogle;
-    }
+		try {
+			localEvent.updateEventDetails(eventData.getSummary(), LocalDate.parse(eventData.getStart().getDate()),
+					localEvent.getEventTime(), localEvent.getEventType());
+		} catch (Exception e) {
+			log.error("로컬 DB 동기화 오류", e);
+		}
+		return responseFromGoogle;
+	}
 
-	@Transactional 
+	@Transactional
 	public void deleteCalendarEvent(String userEmail, String eventId) {
-        String accessToken = tokenManagerService.getToken(userEmail, "google");
-        if (accessToken == null || accessToken.isEmpty()) {
-            throw new GoogleOAuthException("Google Access Token이 유효하지 않습니다.");
-        }
+		String accessToken = tokenManagerService.getToken(userEmail, "google");
+		if (accessToken == null || accessToken.isEmpty()) {
+			throw new GoogleOAuthException("Google Access Token이 유효하지 않습니다.");
+		}
 
-        MeetUser user = meetUserRepository.findByEmail(userEmail)
-                .orElseThrow(() -> new ResourceNotFoundException("사용자를 찾을 수 없습니다: " + userEmail));
+		MeetUser user = meetUserRepository.findByEmail(userEmail)
+				.orElseThrow(() -> new ResourceNotFoundException("사용자를 찾을 수 없습니다: " + userEmail));
 
-        CalendarEvent localEvent = calendarEventRepository.findByGoogleEventIdAndUserId(eventId, user.getId())
-                .orElseThrow(() -> new ResourceNotFoundException("로컬 이벤트를 찾을 수 없습니다: " + eventId));
+		CalendarEvent localEvent = calendarEventRepository.findByGoogleEventIdAndUserId(eventId, user.getId())
+				.orElseThrow(() -> new ResourceNotFoundException("로컬 이벤트를 찾을 수 없습니다: " + eventId));
 
-        try {
-            googleCalendarApiClient.deleteEvent(accessToken, "primary", eventId);
-        } catch (Exception e) {
-            if (e.getMessage() != null && e.getMessage().contains("invalid_grant")) {
-                throw new GoogleOAuthException("Google 토큰 갱신 실패(invalid_grant)");
-            }
-            log.warn("Google API 삭제 실패 (로컬만 삭제 진행): " + e.getMessage());
-        }
-        calendarEventRepository.delete(localEvent);
-    }
-	// 중요도 표기 API
-	public void toggleImportance(Long eventId) {
-		CalendarEvent event = calendarEventRepository.findById(eventId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 일정을 찾을 수 없습니다. id=" + eventId));
-        
-        // 엔티티의 편의 메서드 호출 (isImportant 상태 반전)
-        event.toggleImportance();		
+		try {
+			googleCalendarApiClient.deleteEvent(accessToken, "primary", eventId);
+		} catch (Exception e) {
+			if (e.getMessage() != null && e.getMessage().contains("invalid_grant")) {
+				throw new GoogleOAuthException("Google 토큰 갱신 실패(invalid_grant)");
+			}
+			log.warn("Google API 삭제 실패 (로컬만 삭제 진행): " + e.getMessage());
+		}
+		calendarEventRepository.delete(localEvent);
+	}
+
+	@Transactional
+	public void toggleImportance(String userEmail, String eventId) {
+		MeetUser user = meetUserRepository.findByEmail(userEmail)
+				.orElseThrow(() -> new ResourceNotFoundException("사용자를 찾을 수 없습니다: " + userEmail));
+
+		Optional<CalendarEvent> localEventOpt = calendarEventRepository.findByGoogleEventIdAndUserId(eventId,
+				user.getId());
+
+		if (localEventOpt.isPresent()) {
+			localEventOpt.get().toggleImportance();
+		} else {
+			log.info("로컬에 없는 이벤트(Google) 발견. 구글 API에서 정보를 가져옵니다. Event ID: {}", eventId);
+
+			String accessToken = tokenManagerService.getToken(userEmail, "google");
+
+			if (accessToken == null) {
+				throw new GoogleOAuthException("구글 연동 토큰이 만료되어 정보를 가져올 수 없습니다.");
+			}
+
+			try {
+			} catch (Exception e) {
+				log.error("구글 이벤트 조회 실패", e);
+			}
+			CalendarEvent newLocalEvent = CalendarEvent.builder().userId(user.getId()).googleEventId(eventId)
+					.isImportant(true).title("외부 일정 (동기화됨)") // <--- 1. 제목을 좀 더 자연스럽게 변경
+					.eventDate(LocalDate.now()) // <--- 2. 날짜는 API 호출 없이는 알기 힘듦 (여전히 오늘로 잡힘)
+					.eventType(EventType.MEETING) // <--- 3. TASK 대신 MEETING으로 변경하면 캘린더에 뜰 확률 높음
+					.build();
+			calendarEventRepository.save(newLocalEvent);
+		}
 	}
 }


### PR DESCRIPTION
## **구현 기능 요약**

- 캘린더 페이지 내 '중요 표시(★)' 기능을 활성화하고, 해당 데이터를 메인 페이지의 '다가오는 중요 회의' 섹션과 연동합니다.

- Google Calendar API를 통해 유입된 외부 일정(로컬 DB에 없는 일정)도 사용자가 중요 표시를 할 수 있으며, 새로고침 시에도 isImportant 상태가 유지되도록 백엔드 동기화 로직을 개선했습니다.
---

## **개발 내역 상세**

1. CalendarEventController (API 엔드포인트 신설)
* PATCH /api/calendar/{eventId}/importance API를 신규 추가했습니다.
* 프론트엔드에서 Google Event ID(String)를 전송하면, @PathVariable("eventId") String eventId로 받아 서비스에 전달합니다.

2. CalendarEventService (핵심 로직 구현)
* userEmail과 eventId를 받아 로컬 DB에서 findByGoogleEventIdAndUserId로 일정을 조회합니다.
* (일정 존재 시): CalendarEvent 엔티티의 toggleImportance() 메서드를 호출하여 isImportant 상태를 반전시킵니다.
* (일정 미존재 시 / 외부 일정): 404 에러 대신, isImportant = true로 설정된 새로운 CalendarEvent 레코드를 생성하여 로컬 DB에 저장합니다. (Google 일정의 로컬 동기화)

3. getEventsByDateRange (데이터 병합 로직 수정)
* (문제): 새로고침 시 Google API 데이터가 로컬 DB의 isImportant 상태를 덮어쓰는 문제.
* (해결):
1) 먼저 로컬 DB의 이벤트를 조회하여 Map<GoogleEventId, CalendarEvent>로 변환합니다.

2) Google Calendar API에서 googleEvents 목록을 조회합니다.

3) googleEvents 목록을 순회하며 로컬 맵(localEventMap)에 일치하는 항목이 있는지 확인합니다.

4) (일치 시): Google DTO 객체(gEvent)에 로컬 DB의 isImportant, eventType, id 값을 **강제로 덮어쓰기(Merge)**하여 데이터 일관성을 확보했습니다.
---

## **검증 방법**
1. 캘린더(일정 관리) 페이지로 이동합니다.
2. To-Do 또는 회의 항목(로컬 생성)의 별(★) 아이콘을 클릭합니다.
3. 페이지를 **새로고침(F5)**해도 방금 클릭한 별 아이콘이 유지되는지 확인합니다.
4. Google Calendar에서 직접 생성한 외부 일정에 대해서도 2~3번 항목이 동일하게 작동하는지 확인합니다.
5. 메인 페이지(대시보드)로 이동하여 "다가오는 중요 회의" 섹션에 방금 별표를 누른 항목이 표시되는지 확인합니다.
6. 캘린더에서 다시 별표를 해제한 후, 새로고침하고 메인 페이지에서도 해당 항목이 사라지는지 확인합니다.
---
