### PR TITLE
feat: [BE] 홈-일정관리 페이지 간 To-Do 상태 연동

### DIFF
--- a/src/main/java/com/dialog/GlobalExceptionHandler.java
+++ b/src/main/java/com/dialog/GlobalExceptionHandler.java
@@ -1,20 +1,20 @@
 package com.dialog;
-
-import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.security.authentication.DisabledException;
+
+import com.dialog.exception.AccessDeniedException;
 import com.dialog.exception.GoogleOAuthException;
-import com.dialog.exception.GoogleOAuthException.AccessDeniedException;
-import com.dialog.exception.GoogleOAuthException.ResourceNotFoundException;
+
 import com.dialog.exception.InactiveUserException;
 import com.dialog.exception.InvalidJwtTokenException;
 import com.dialog.exception.InvalidPasswordException;
 import com.dialog.exception.OAuthUserNotFoundException;
 import com.dialog.exception.RefreshTokenException;
+import com.dialog.exception.ResourceNotFoundException;
 import com.dialog.exception.SocialUserInfoException;
 import com.dialog.exception.SocialUserSaveException;
 import com.dialog.exception.TermsNotAcceptedException;

--- a/src/main/java/com/dialog/calendarevent/controller/CalendarEventController.java
+++ b/src/main/java/com/dialog/calendarevent/controller/CalendarEventController.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.dialog.calendarevent.domain.CalendarCreateRequest;
 import com.dialog.calendarevent.domain.CalendarEventResponse;
+import com.dialog.calendarevent.domain.EventCompletionRequest;
 import com.dialog.calendarevent.domain.GoogleEventResponseDTO;
 import com.dialog.calendarevent.service.CalendarEventService;
 import com.dialog.token.service.SocialTokenService;
@@ -37,7 +38,7 @@ import lombok.extern.log4j.Log4j2;
 public class CalendarEventController {
 
 	private final CalendarEventService calendarEventService;
-	private final SocialTokenService tokenManagerService;
+	private final SocialTokenService tokenManagerService;	
 
 	@GetMapping("/calendar/events")
 	public ResponseEntity<List<CalendarEventResponse>> getEvents(Principal principal, // ResponseEntity<?> ->
@@ -130,4 +131,21 @@ public class CalendarEventController {
 
         return ResponseEntity.ok().build();
     }
+	@PatchMapping("/calendar/events/{eventId}/completion")
+    public ResponseEntity<Void> updateEventCompletion(
+            @PathVariable("eventId") String eventId,
+            @RequestBody EventCompletionRequest request,
+            Principal principal) {
+
+        if (principal == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        
+        String userEmail = principal.getName();        
+
+        calendarEventService.updateCompletionStatus(userEmail, eventId, request.isCompleted());
+
+        return ResponseEntity.ok().build();
+    }
+	
 }

--- a/src/main/java/com/dialog/calendarevent/domain/CalendarEvent.java
+++ b/src/main/java/com/dialog/calendarevent/domain/CalendarEvent.java
@@ -21,8 +21,8 @@ public class CalendarEvent {
 	private Long id;
 
 	@Column(nullable = false)
-	private Long userId; 
-	
+	private Long userId;
+
 	@Column(nullable = false)
 	private String title;
 
@@ -30,7 +30,7 @@ public class CalendarEvent {
 	private LocalDate eventDate;
 
 	// 시간이 있는 일정일 경우 사용
-	private LocalTime eventTime; 
+	private LocalTime eventTime;
 
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false, length = 10)
@@ -38,22 +38,24 @@ public class CalendarEvent {
 
 	// 중요 표시 (DB: TINYINT(1) / Java: boolean)
 	@Column(nullable = false)
-	private boolean isImportant; 
+	private boolean isImportant;
+	
+	@Column(nullable = false)
+    private boolean isCompleted = false;
 
 	// ------------------ 관계 필드 ------------------
 	private Long taskId;
 	private Long meetingId;
 	private String googleEventId;
 
-    // 생성/수정 시간 필드 (DB 테이블에 created_at이 있으므로 필요)
-    @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-    
+	// 생성/수정 시간 필드 (DB 테이블에 created_at이 있으므로 필요)
+	@Column(nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
 	// ------------------ 1. Builder 패턴을 사용한 생성자 ------------------
 	@Builder
-	public CalendarEvent(Long userId, String title, LocalDate eventDate, LocalTime eventTime,
-			             EventType eventType, boolean isImportant, Long taskId, Long meetingId, 
-                         String googleEventId) {
+	public CalendarEvent(Long userId, String title, LocalDate eventDate, LocalTime eventTime, EventType eventType,
+			boolean isImportant, Long taskId, Long meetingId, String googleEventId) {
 		this.userId = userId;
 		this.title = title;
 		this.eventDate = eventDate;
@@ -63,21 +65,25 @@ public class CalendarEvent {
 		this.taskId = taskId;
 		this.meetingId = meetingId;
 		this.googleEventId = googleEventId;
-        this.createdAt = LocalDateTime.now();
+		this.createdAt = LocalDateTime.now();
 	}
-    
-    // ------------------ 3. 비즈니스 로직 기반 업데이트 메서드 ------------------
-    /**
-     * 일정 제목, 날짜, 타입 등 핵심 내용을 업데이트
-     */
-    public void updateEventDetails(String title, LocalDate eventDate, LocalTime eventTime, EventType eventType) {
-        this.title = title;
-        this.eventDate = eventDate;
-        this.eventTime = eventTime;
-        this.eventType = eventType;
-    }    
 
-    public void toggleImportance() {
-        this.isImportant = !this.isImportant;
+	// ------------------ 3. 비즈니스 로직 기반 업데이트 메서드 ------------------
+	/**
+	 * 일정 제목, 날짜, 타입 등 핵심 내용을 업데이트
+	 */
+	public void updateEventDetails(String title, LocalDate eventDate, LocalTime eventTime, EventType eventType) {
+		this.title = title;
+		this.eventDate = eventDate;
+		this.eventTime = eventTime;
+		this.eventType = eventType;
+	}
+
+	public void toggleImportance() {
+		this.isImportant = !this.isImportant;
+	}
+	
+	public void setIsCompleted(boolean completed) {
+        this.isCompleted = completed;
     }
 }

--- a/src/main/java/com/dialog/calendarevent/domain/CalendarEventResponse.java
+++ b/src/main/java/com/dialog/calendarevent/domain/CalendarEventResponse.java
@@ -30,6 +30,9 @@ public class CalendarEventResponse {
 	
 	@JsonProperty("isImportant")
 	private boolean isImportant;
+	@JsonProperty("isCompleted")
+    private boolean isCompleted;
+	
 	private String sourceId;
 	private String googleEventId;
 	private LocalDateTime createdAt;
@@ -51,6 +54,6 @@ public class CalendarEventResponse {
 		return CalendarEventResponse.builder().id(entity.getId()).userId(entity.getUserId()).title(entity.getTitle())
 				.eventDate(entity.getEventDate() != null ? entity.getEventDate().toString() : null)
 				.time(entity.getEventTime()).eventType(entity.getEventType().name()).isImportant(entity.isImportant())
-				.sourceId(sourceId).googleEventId(entity.getGoogleEventId()).createdAt(entity.getCreatedAt()).build();
+				.isCompleted(entity.isCompleted()).sourceId(sourceId).googleEventId(entity.getGoogleEventId()).createdAt(entity.getCreatedAt()).build();
 	}
 }

--- a/src/main/java/com/dialog/calendarevent/domain/EventCompletionRequest.java
+++ b/src/main/java/com/dialog/calendarevent/domain/EventCompletionRequest.java
@@ -1,0 +1,13 @@
+package com.dialog.calendarevent.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class EventCompletionRequest {
+	@JsonProperty("isCompleted")
+	private boolean isCompleted;
+}

--- a/src/main/java/com/dialog/exception/AccessDeniedException.java
+++ b/src/main/java/com/dialog/exception/AccessDeniedException.java
@@ -1,0 +1,7 @@
+package com.dialog.exception;
+
+public class AccessDeniedException extends RuntimeException {
+    public AccessDeniedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/dialog/exception/GoogleOAuthException.java
+++ b/src/main/java/com/dialog/exception/GoogleOAuthException.java
@@ -10,18 +10,5 @@ public class GoogleOAuthException extends RuntimeException {
     public GoogleOAuthException(String message, Throwable cause) {
         super(message, cause);
     }
-	
-	// 2. 리소스를 찾을 수 없음 예외 (404) - Optional
-	public static class ResourceNotFoundException extends RuntimeException {
-	    public ResourceNotFoundException(String message) {
-	        super(message);
-	    }
-	}
-	
-	// 3. 권한 없음 예외 (403) - Optional (기존 IllegalAccessException 대체용)
-	public static class AccessDeniedException extends RuntimeException {
-	    public AccessDeniedException(String message) {
-	        super(message);
-	    }
-	}
+
 }

--- a/src/main/java/com/dialog/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/dialog/exception/ResourceNotFoundException.java
@@ -1,0 +1,7 @@
+package com.dialog.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/dialog/token/service/SocialTokenService.java
+++ b/src/main/java/com/dialog/token/service/SocialTokenService.java
@@ -7,9 +7,8 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
-
+import com.dialog.exception.ResourceNotFoundException;
 import com.dialog.exception.GoogleOAuthException;
-import com.dialog.exception.GoogleOAuthException.ResourceNotFoundException; 
 import com.dialog.calendarevent.service.GoogleTokenDto;
 import com.dialog.googleauth.domain.GoogleAuthDTO;
 import com.dialog.token.domain.UserSocialToken;

--- a/src/main/java/com/dialog/user/service/MeetuserService.java
+++ b/src/main/java/com/dialog/user/service/MeetuserService.java
@@ -78,8 +78,7 @@ public class MeetuserService {
     }
     
 //      로그인 검증
-//      이메일 DB조회 -> 비밀번호 비교 (암호화 검증) -> 오류시 예외 반환, 성공시 유저 엔티티 반환
-     
+//      이메일 DB조회 -> 비밀번호 비교 (암호화 검증) -> 오류시 예외 반환, 성공시 유저 엔티티 반환     
     public MeetUser login(String email, String rawPassword) {
         MeetUser user = meetUserRepository.findByEmail(email)
                 .orElseThrow(() -> new UserNotFoundException("존재하지 않는 사용자 입니다."));


### PR DESCRIPTION
## **구현 기능 요약**
- To-Do 완료 상태(isCompleted)가 DB에 저장되지 않고, GET API 응답에도 누락되어 프론트엔드와 동기화되지 않던 버그를 수정
- home.js의 PATCH 요청을 서버가 false로 저장하는 DTO 매핑 문제를 해결
- GET /api/calendar/events API 응답에 isCompleted 필드가 누락되는 문제 해결
---

## **개발 내역 상세**
1. DB 저장 (쓰기): home.js가 보낸 isCompleted: true 값을 false로 잘못 받던 DTO(EventCompletionRequest) 버그를 @JsonProperty로 수정하고, Controller와 Service에 PATCH 요청 처리 및 DB 저장 로직을 구현했습니다.

2. 엔티티 수정: CalendarEvent 엔티티에 isCompleted 필드와 setIsCompleted 메서드를 추가했습니다.

3. 상태 조회 (읽기): GET API가 저장된 완료 상태를 프론트엔드로 다시 보내주도록, 응답 DTO(CalendarEventResponse)에도 isCompleted 필드를 추가했습니다.
---

## **검증 방법**
1.  home.html 페이지에서 To-Do 항목의 체크박스를 클릭합니다.

2. 브라우저 개발자 도구(F12) [Network] 탭에서 completion (PATCH) 요청이 200 OK로 응답하는지 확인합니다.

3. 백엔드(Spring) 콘솔 로그에 이벤트 완료 상태 변경 (ID: xxx, 완료: true) 로그가 찍히는지 확인합니다.

4. DB 툴에서 calendar_event 테이블의 해당 id를 조회하여, is_completed 컬럼 값이 1 (true)로 변경되었는지 확인합니다.

5. home.html 페이지 새로고침(F5) 후 [Network] 탭에서 GET .../events 요청의 응답(Response)에 isCompleted: true가 포함되어 오는지 확인하고, To-Do 항목의 취소선이 유지되는지 확인합니다.

6. calendar.html 페이지로 이동하여 사이드바와 상세 오버레이에 해당 To-Do가 완료 상태(취소선, "(확인)" 텍스트)로 표시되는지 최종 확인합니다.
---
