### PR TITLE
feat: [BE] STT 발화자 구분 서버와 회의 완료 페이지 연결

### DIFF
--- a/src/main/java/com/dialog/meeting/domain/Meeting.java
+++ b/src/main/java/com/dialog/meeting/domain/Meeting.java
@@ -10,6 +10,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 import com.dialog.keyword.domain.Keyword;
 import com.dialog.participant.domain.Participant;
 import com.dialog.recording.domain.Recording;
+import com.dialog.transcript.domain.Transcript;
 import com.dialog.user.domain.MeetUser;
 
 import jakarta.persistence.CascadeType;
@@ -85,9 +86,14 @@ public class Meeting {
 	@OneToMany(mappedBy = "meeting", fetch = FetchType.LAZY)
 	private List<Participant> participants;
 	
-	// Meeting.java에 추가
-	@OneToOne(mappedBy = "meeting", cascade = CascadeType.ALL, orphanRemoval = true)
-	private Recording recording;
+	// 1:1 Recording 설정
+    @OneToOne(mappedBy = "meeting", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private Recording recording;
+
+	// 1:N Transcript 설정
+    @OneToMany(mappedBy = "meeting", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<Transcript> transcripts = new ArrayList<>();
+
 	
 	// 키워드 연관관계 (다대다)
 	@Builder.Default

--- a/src/main/java/com/dialog/meeting/domain/MeetingFinishRequestDto.java
+++ b/src/main/java/com/dialog/meeting/domain/MeetingFinishRequestDto.java
@@ -1,6 +1,6 @@
 package com.dialog.meeting.domain;
 
-//import java.util.List;
+import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -12,19 +12,8 @@ public class MeetingFinishRequestDto {
     
     private Integer duration;  // 회의 진행 시간 (초)
     private String endTime;    // 종료 시간 (ISO format)
-//    private List<TranscriptDto> transcripts;  // 대화 내용
-    private Integer sentenceCount;  // 문장 수
-    private Double avgConfidence;  // 평균 신뢰도
     private RecordingData recording;  // 녹음 파일 정보
-    
-//    @Getter
-//    @Setter
-//    @NoArgsConstructor
-//    public static class TranscriptDto {
-//        private String speaker;  // 발화자
-//        private String time;     // 시간
-//        private String text;     // 내용
-//    }
+    private List<TranscriptData> transcripts;
     
     @Getter
     @Setter
@@ -34,5 +23,19 @@ public class MeetingFinishRequestDto {
         private String audioFormat;       // 오디오 형식 (wav, mp3 등)
         private Long audioFileSize;       // 파일 크기 (bytes)
         private Integer durationSeconds;  // 녹음 길이 (초)
+    }
+    
+    // 🆕 발화자 구분 데이터 (신뢰도 제외)
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class TranscriptData {
+        private String speakerId;       // 원본 화자 ID (예: spk-1)
+        private String speakerName;     // 매핑된 실제 이름
+        private Integer speakerLabel;   // CLOVA speaker label
+        private String text;            // 발화 내용
+        private Long startTime;         // 시작 시간 (ms)
+        private Long endTime;           // 종료 시간 (ms)
+        private Integer sequenceOrder;  // 발화 순서
     }
 }

--- a/src/main/java/com/dialog/meeting/service/MeetingService.java
+++ b/src/main/java/com/dialog/meeting/service/MeetingService.java
@@ -20,145 +20,141 @@ import com.dialog.participant.domain.Participant;
 import com.dialog.participant.repository.ParticipantRepository;
 import com.dialog.recording.domain.Recording;
 import com.dialog.recording.repository.RecordingRepository;
+import com.dialog.transcript.domain.Transcript;
+import com.dialog.transcript.repository.TranscriptRepository;
 import com.dialog.user.domain.MeetUser;
 import com.dialog.user.repository.MeetUserRepository;
 
 import lombok.RequiredArgsConstructor;
 
-
 @Service
-@RequiredArgsConstructor 
-@Transactional(readOnly = true) 
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MeetingService {
 
-    private final MeetingRepository meetingRepository;
-    private final MeetUserRepository meetUserRepository; 
-    private final ParticipantRepository participantRepository;
-    private final KeywordRepository keywordRepository;
-    private final RecordingRepository recordingRepository;
-    
-    // 회의 생성
-    @Transactional 
-    public MeetingCreateResponseDto createMeeting(MeetingCreateRequestDto requestDto, Long hostUserId) throws IllegalAccessException {
+	private final MeetingRepository meetingRepository;
+	private final MeetUserRepository meetUserRepository;
+	private final ParticipantRepository participantRepository;
+	private final KeywordRepository keywordRepository;
+	private final RecordingRepository recordingRepository;
+	private final TranscriptRepository 	transcriptRepository;
 
-        // 1. 주최자(User) 엔티티 조회
-        MeetUser hostUser = meetUserRepository.findById(hostUserId)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+	// 회의 생성
+	@Transactional
+	public MeetingCreateResponseDto createMeeting(MeetingCreateRequestDto requestDto, Long hostUserId)
+			throws IllegalAccessException {
 
-        // 2. 빌더 패턴을 사용해 DTO를 Meeting 엔티티로 변환
-        LocalDateTime scheduledAt;
-        try {
-            scheduledAt = LocalDateTime.parse(requestDto.getScheduledAt());
-        } catch (DateTimeParseException e) {
-            throw new IllegalAccessException("잘못된 날짜 형식입니다. yyyy-MM-dd'T'HH:mm:ss 형식으로 보내야 합니다.");
-        }
-        Meeting newMeeting = Meeting.builder()
-                .title(requestDto.getTitle())
-                .description(requestDto.getDescription())
-                .scheduledAt(scheduledAt)
-                .hostUser(hostUser)
-                .build();
+		// 1. 주최자(User) 엔티티 조회
+		MeetUser hostUser = meetUserRepository.findById(hostUserId)
+				.orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
-        // 3. 엔티티를 DB에 저장
-        Meeting savedMeeting = meetingRepository.save(newMeeting);
+		// 2. 빌더 패턴을 사용해 DTO를 Meeting 엔티티로 변환
+		LocalDateTime scheduledAt;
+		try {
+			scheduledAt = LocalDateTime.parse(requestDto.getScheduledAt());
+		} catch (DateTimeParseException e) {
+			throw new IllegalAccessException("잘못된 날짜 형식입니다. yyyy-MM-dd'T'HH:mm:ss 형식으로 보내야 합니다.");
+		}
+		Meeting newMeeting = Meeting.builder().title(requestDto.getTitle()).description(requestDto.getDescription())
+				.scheduledAt(scheduledAt).hostUser(hostUser).build();
 
-        // 4. 참석자 등록
-        List<Participant> participantEntities = new ArrayList<>();
-        for (String speakerId : requestDto.getParticipants()) {
-            Participant participant = Participant.builder()
-                .meeting(savedMeeting)
-                .speakerId(speakerId)
-                .name(speakerId) 
-                .build();
-            participantEntities.add(participant);
-        }
-        participantRepository.saveAll(participantEntities);
-        
-        // 5. 키워드 등록 및 ManyToMany 연관관계 설정
-        // 기존 키워드 재사용(중복사용방지) , 없으면 새로 생성하여 저장
-        List<Keyword> keywordEntities = new ArrayList<>();
-        if (requestDto.getKeywords() != null) {
-            for (String keywordName : requestDto.getKeywords()) {
-            	// keywordRepository.findByName(keywordName) -> DB 에 해당 키워드가 있는지 먼저 조회
-                Keyword keyword = keywordRepository.findByName(keywordName)
-                		// 없으면 새로 생성해서 DB 에 저장후 반환
-                    .orElseGet(() -> keywordRepository.save(Keyword.builder().name(keywordName).build()));
-                keywordEntities.add(keyword);
-            }
-            savedMeeting.getKeywords().addAll(keywordEntities);
-            meetingRepository.save(savedMeeting);
-        }
+		// 3. 엔티티를 DB에 저장
+		Meeting savedMeeting = meetingRepository.save(newMeeting);
 
-        // 6. 응답 반환 세팅 (이름/키워드 스트링값만 추출)
-        List<String> participantIds = new ArrayList<>();
-        for (Participant participant : participantEntities) {
-            participantIds.add(participant.getSpeakerId());
-        }
+		// 4. 참석자 등록
+		List<Participant> participantEntities = new ArrayList<>();
+		for (String speakerId : requestDto.getParticipants()) {
+			Participant participant = Participant.builder().meeting(savedMeeting).speakerId(speakerId).name(speakerId)
+					.build();
+			participantEntities.add(participant);
+		}
+		participantRepository.saveAll(participantEntities);
 
-        List<String> keywordNames = new ArrayList<>();
-        for (Keyword k : keywordEntities) {
-            keywordNames.add(k.getName());
-        }
+		// 5. 키워드 등록 및 ManyToMany 연관관계 설정
+		// 기존 키워드 재사용(중복사용방지) , 없으면 새로 생성하여 저장
+		List<Keyword> keywordEntities = new ArrayList<>();
+		if (requestDto.getKeywords() != null) {
+			for (String keywordName : requestDto.getKeywords()) {
+				// keywordRepository.findByName(keywordName) -> DB 에 해당 키워드가 있는지 먼저 조회
+				Keyword keyword = keywordRepository.findByName(keywordName)
+						// 없으면 새로 생성해서 DB 에 저장후 반환
+						.orElseGet(() -> keywordRepository.save(Keyword.builder().name(keywordName).build()));
+				keywordEntities.add(keyword);
+			}
+			savedMeeting.getKeywords().addAll(keywordEntities);
+			meetingRepository.save(savedMeeting);
+		}
 
-        return new MeetingCreateResponseDto(savedMeeting, participantIds, keywordNames);
-        
-    }
-	public MeetingCreateResponseDto findById(Long meetingId) {
-        // 1. 회의 조회
-        Meeting meeting = meetingRepository.findById(meetingId)
-            .orElseThrow(() -> new IllegalArgumentException("회의를 찾을 수 없습니다."));
-        
-        // 2. 해당 회의 id 값을 통해 참가자 조회
-        List<Participant> participantEntities = participantRepository.findByMeetingId(meetingId);
-        // 3. 참가자의 이름만 뽑아서 List 로 추출
-        List<String> participants = new ArrayList<>();
-        for (Participant p : participantEntities) {
-            participants.add(p.getSpeakerId());
-        }
+		// 6. 응답 반환 세팅 (이름/키워드 스트링값만 추출)
+		List<String> participantIds = new ArrayList<>();
+		for (Participant participant : participantEntities) {
+			participantIds.add(participant.getSpeakerId());
+		}
 
-        // 4. 해당 회의 id 값을 통해 하이라이트 조회
-        List<Keyword> highlightEntities = keywordRepository.findByMeetingsId(meetingId);
-        // 5. 하이라이트의 키워드만 뽑아서 List 로 추출
-        List<String> keywords = new ArrayList<>();
-        for (Keyword h : highlightEntities) {
-            keywords.add(h.getName());
-        }
-        // 6. List 로 추출한 키워드, 참가자 이름을 DTO로 반환
-        return new MeetingCreateResponseDto(meeting, participants, keywords);
-    }
-	
-	public List<MeetingCreateResponseDto> getAllMeetings() {
-	    List<Meeting> meetings = meetingRepository.findAll();
-	    return meetings.stream()
-	            .map(meeting -> {
-	                List<String> participantNames = meeting.getParticipants().stream()
-	                        .map(Participant::getName) // 또는 Participant::getSpeakerId
-	                        .collect(Collectors.toList());
+		List<String> keywordNames = new ArrayList<>();
+		for (Keyword k : keywordEntities) {
+			keywordNames.add(k.getName());
+		}
 
-	                List<String> keywordTexts = meeting.getKeywords().stream()
-	                        .map(Keyword::getName)
-	                        .collect(Collectors.toList());
+		return new MeetingCreateResponseDto(savedMeeting, participantIds, keywordNames);
 
-	                return new MeetingCreateResponseDto(meeting, participantNames, keywordTexts);
-	            })
-	            .collect(Collectors.toList());
 	}
-	
-	// 회의 종료 추가 -> recording 저장
+
+	public MeetingCreateResponseDto findById(Long meetingId) {
+		// 1. 회의 조회
+		Meeting meeting = meetingRepository.findById(meetingId)
+				.orElseThrow(() -> new IllegalArgumentException("회의를 찾을 수 없습니다."));
+
+		// 2. 해당 회의 id 값을 통해 참가자 조회
+		List<Participant> participantEntities = participantRepository.findByMeetingId(meetingId);
+		// 3. 참가자의 이름만 뽑아서 List 로 추출
+		List<String> participants = new ArrayList<>();
+		for (Participant p : participantEntities) {
+			participants.add(p.getSpeakerId());
+		}
+
+		// 4. 해당 회의 id 값을 통해 하이라이트 조회
+		List<Keyword> highlightEntities = keywordRepository.findByMeetingsId(meetingId);
+		// 5. 하이라이트의 키워드만 뽑아서 List 로 추출
+		List<String> keywords = new ArrayList<>();
+		for (Keyword h : highlightEntities) {
+			keywords.add(h.getName());
+		}
+		// 6. List 로 추출한 키워드, 참가자 이름을 DTO로 반환
+		return new MeetingCreateResponseDto(meeting, participants, keywords);
+	}
+
+	public List<MeetingCreateResponseDto> getAllMeetings() {
+		List<Meeting> meetings = meetingRepository.findAll();
+		return meetings.stream().map(meeting -> {
+			List<String> participantNames = meeting.getParticipants().stream().map(Participant::getName) // 또는
+																											// Participant::getSpeakerId
+					.collect(Collectors.toList());
+
+			List<String> keywordTexts = meeting.getKeywords().stream().map(Keyword::getName)
+					.collect(Collectors.toList());
+
+			return new MeetingCreateResponseDto(meeting, participantNames, keywordTexts);
+		}).collect(Collectors.toList());
+	}
+
+	// MeetingService.java의 finishMeeting 메서드만 수정
+
+	// 🆕 회의 종료 + Transcript 저장
 	@Transactional
 	public void finishMeeting(Long meetingId, MeetingFinishRequestDto requestDto) {
+
 	    // 1. 회의 조회
 	    Meeting meeting = meetingRepository.findById(meetingId)
 	            .orElseThrow(() -> new IllegalArgumentException("회의를 찾을 수 없습니다. ID: " + meetingId));
-	    
+
 	    // 2. 회의 상태를 COMPLETED로 변경
 	    meeting.complete();
-	    
+
 	    // 3. Recording 정보가 있으면 저장
 	    if (requestDto.getRecording() != null) {
 	        MeetingFinishRequestDto.RecordingData recordingData = requestDto.getRecording();
-	        
-	        // 이미 Recording이 있는지 확인
+
 	        if (!recordingRepository.existsByMeetingId(meetingId)) {
 	            Recording recording = Recording.builder()
 	                    .meeting(meeting)
@@ -167,12 +163,38 @@ public class MeetingService {
 	                    .audioFormat(recordingData.getAudioFormat())
 	                    .durationSeconds(recordingData.getDurationSeconds())
 	                    .build();
-	            
+
 	            recordingRepository.save(recording);
 	        }
 	    }
-	    
-	    // 4. 회의 엔티티 저장 (상태 변경 반영)
+
+	    // 🆕 4. Transcript 정보가 있으면 저장 (✅ 활성화됨)
+	    if (requestDto.getTranscripts() != null && !requestDto.getTranscripts().isEmpty()) {
+
+	        // 기존 Transcript가 있다면 삭제 (중복 방지)
+	        if (transcriptRepository.existsByMeetingId(meetingId)) {
+	            transcriptRepository.deleteByMeetingId(meetingId);
+	        }
+
+	        // Transcript 엔티티 생성 및 저장
+	        List<Transcript> transcripts = requestDto.getTranscripts().stream()
+	                .map(transcriptData -> Transcript.builder()
+	                        .meeting(meeting)
+	                        .speakerId(transcriptData.getSpeakerId())
+	                        .speakerName(transcriptData.getSpeakerName())
+	                        .speakerLabel(transcriptData.getSpeakerLabel())
+	                        .text(transcriptData.getText())
+	                        .startTime(transcriptData.getStartTime())
+	                        .endTime(transcriptData.getEndTime())
+	                        .sequenceOrder(transcriptData.getSequenceOrder())
+	                        .isDeleted(false)  // 기본값 추가
+	                        .build())
+	                .collect(Collectors.toList());
+
+	        transcriptRepository.saveAll(transcripts);
+	    } 
+
+	    // 5. 회의 엔티티 저장 (상태 변경 반영)
 	    meetingRepository.save(meeting);
 	}
 }

--- a/src/main/java/com/dialog/recording/domain/Recording.java
+++ b/src/main/java/com/dialog/recording/domain/Recording.java
@@ -7,8 +7,21 @@ import org.hibernate.annotations.UpdateTimestamp;
 
 import com.dialog.meeting.domain.Meeting;
 
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "recording")
@@ -22,7 +35,7 @@ public class Recording {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "meeting_id", nullable = false, unique = true)
     private Meeting meeting;
     

--- a/src/main/java/com/dialog/transcript/controller/TranscriptController.java
+++ b/src/main/java/com/dialog/transcript/controller/TranscriptController.java
@@ -1,0 +1,99 @@
+package com.dialog.transcript.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import com.dialog.transcript.domain.TranscriptCreateRequestDto;
+import com.dialog.transcript.domain.TranscriptResponseDto;
+import com.dialog.transcript.service.TranscriptService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/transcripts")
+@RequiredArgsConstructor
+public class TranscriptController {
+
+    private final TranscriptService transcriptService;
+
+    // 단일 Transcript 저장
+    @PostMapping
+    public ResponseEntity<TranscriptResponseDto> createTranscript(
+            @RequestParam("meetingId") Long meetingId,
+            @RequestBody TranscriptCreateRequestDto requestDto) {
+        try {
+            TranscriptResponseDto response = transcriptService.saveTranscript(meetingId, requestDto);
+            return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        } catch (IllegalArgumentException e) {
+            log.error("Transcript 생성 실패: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
+    }
+
+    // 일괄 Transcript 저장
+    @PostMapping("/batch")
+    public ResponseEntity<List<TranscriptResponseDto>> createTranscripts(
+            @RequestParam("meetingId") Long meetingId,
+            @RequestBody List<TranscriptCreateRequestDto> requestDtos) {
+        try {
+            List<TranscriptResponseDto> responses = transcriptService.saveTranscripts(meetingId, requestDtos);
+            return ResponseEntity.status(HttpStatus.CREATED).body(responses);
+        } catch (IllegalArgumentException e) {
+            log.error("Transcript 일괄 생성 실패: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
+    }
+
+    // Meeting ID로 Transcript 조회
+    @GetMapping("/meeting/{meetingId}")
+    public ResponseEntity<List<TranscriptResponseDto>> getTranscriptsByMeeting(
+            @PathVariable("meetingId") Long meetingId) {
+        try {
+            List<TranscriptResponseDto> responses = transcriptService.getTranscriptsByMeetingId(meetingId);
+            return ResponseEntity.ok(responses);
+        } catch (Exception e) {
+            log.error("Transcript 조회 실패: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    // 특정 화자의 발화만 조회
+    @GetMapping("/meeting/{meetingId}/speaker/{speakerId}")
+    public ResponseEntity<List<TranscriptResponseDto>> getTranscriptsBySpeaker(
+            @PathVariable("meetingId") Long meetingId,
+            @PathVariable("speakerId") String speakerId) {
+        try {
+            List<TranscriptResponseDto> responses = transcriptService.getTranscriptsBySpeaker(meetingId, speakerId);
+            return ResponseEntity.ok(responses);
+        } catch (Exception e) {
+            log.error("화자별 Transcript 조회 실패: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    // Transcript 삭제
+    @DeleteMapping("/{transcriptId}")
+    public ResponseEntity<Void> deleteTranscript(@PathVariable("transcriptId") Long transcriptId) {
+        try {
+            transcriptService.deleteTranscript(transcriptId);
+            return ResponseEntity.noContent().build();
+        } catch (IllegalArgumentException e) {
+            log.error("Transcript 삭제 실패: {}", e.getMessage());
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    // Meeting의 모든 Transcript 삭제
+    @DeleteMapping("/meeting/{meetingId}")
+    public ResponseEntity<Void> deleteTranscriptsByMeeting(@PathVariable("meetingId") Long meetingId) {
+        try {
+            transcriptService.deleteTranscriptsByMeetingId(meetingId);
+            return ResponseEntity.noContent().build();
+        } catch (Exception e) {
+            log.error("Meeting Transcript 일괄 삭제 실패: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+}

--- a/src/main/java/com/dialog/transcript/domain/Transcript.java
+++ b/src/main/java/com/dialog/transcript/domain/Transcript.java
@@ -1,0 +1,125 @@
+package com.dialog.transcript.domain;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import com.dialog.meeting.domain.Meeting;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "transcript")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public class Transcript {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 어떤 회의의 발화인지 (FK) */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "meeting_id", nullable = false)
+    private Meeting meeting;
+
+    /** STT 원본 화자 ID (예: Speaker 1, spk-1) */
+    @Column(name = "speaker_id", length = 50, nullable = false)
+    private String speakerId;
+
+    /** 사용자가 매핑한 최종 화자명 (예: 김민준) */
+    @Column(name = "speaker_name", length = 100)
+    private String speakerName;
+
+    /** CLOVA STT의 speaker label (정수값) */
+    @Column(name = "speaker_label")
+    private Integer speakerLabel;
+
+    /** 실제 발화 내용 */
+    @Lob
+    @Column(nullable = false)
+    private String text;
+
+    /** 시작 시간 (밀리초) */
+    @Column(name = "start_time", nullable = false)
+    private Long startTime;
+
+    /** 종료 시간 (밀리초) */
+    @Column(name = "end_time", nullable = false)
+    private Long endTime;
+
+    /** 발화 순서 */
+    @Column(name = "sequence_order", nullable = false)
+    private Integer sequenceOrder;
+
+    /** 삭제(숨김) 여부 : 프론트의 delete/undo 반영 */
+    @Column(name = "is_deleted", nullable = false)
+    @Builder.Default
+    private boolean isDeleted = false;
+
+    /** 생성 시간 */
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    /** 수정 시간 */
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    /* ==============================
+           비즈니스 로직
+    ============================== */
+
+    /** 발화 텍스트 수정 */
+    public void updateText(String newText) {
+        this.text = newText;
+    }
+
+    /** 발화자 변경 */
+    public void updateSpeaker(String newSpeakerId, String newSpeakerName) {
+        this.speakerId = newSpeakerId;
+        this.speakerName = newSpeakerName;
+    }
+
+    /** 삭제 */
+    public void delete() {
+        this.isDeleted = true;
+    }
+
+    /** 복구 */
+    public void restore() {
+        this.isDeleted = false;
+    }
+
+    /** 프론트 표시용 시간 라벨 생성 (00:01:30 형식) */
+    public String getTimeLabel() {
+        long seconds = this.startTime / 1000;
+        long hours = seconds / 3600;
+        long minutes = (seconds % 3600) / 60;
+        long secs = seconds % 60;
+        
+        if (hours > 0) {
+            return String.format("%02d:%02d:%02d", hours, minutes, secs);
+        } else {
+            return String.format("%02d:%02d", minutes, secs);
+        }
+    }
+}

--- a/src/main/java/com/dialog/transcript/domain/TranscriptCreateRequestDto.java
+++ b/src/main/java/com/dialog/transcript/domain/TranscriptCreateRequestDto.java
@@ -1,0 +1,19 @@
+package com.dialog.transcript.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class TranscriptCreateRequestDto {
+    
+    private String speakerId;       // 원본 화자 ID
+    private String speakerName;     // 매핑된 실제 이름
+    private Integer speakerLabel;   // CLOVA speaker label
+    private String text;            // 발화 내용
+    private Long startTime;         // 시작 시간 (ms)
+    private Long endTime;           // 종료 시간 (ms)
+    private Integer sequenceOrder;  // 발화 순서
+}

--- a/src/main/java/com/dialog/transcript/domain/TranscriptResponseDto.java
+++ b/src/main/java/com/dialog/transcript/domain/TranscriptResponseDto.java
@@ -1,0 +1,46 @@
+package com.dialog.transcript.domain;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class TranscriptResponseDto {
+    
+    private Long id;
+    private Long meetingId;
+    private String speakerId;
+    private String speakerName;
+    private Integer speakerLabel;
+    private String text;
+    private Long startTime;
+    private Long endTime;
+    private Integer sequenceOrder;
+    private String timeLabel;  // 추가: 프론트 표시용
+    private boolean isDeleted;  // 추가: 삭제 여부
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    
+    public TranscriptResponseDto(Transcript transcript) {
+        this.id = transcript.getId();
+        
+        if (transcript.getMeeting() != null) {
+            this.meetingId = transcript.getMeeting().getId();
+        }
+        
+        this.speakerId = transcript.getSpeakerId();
+        this.speakerName = transcript.getSpeakerName();
+        this.speakerLabel = transcript.getSpeakerLabel();
+        this.text = transcript.getText();
+        this.startTime = transcript.getStartTime();
+        this.endTime = transcript.getEndTime();
+        this.sequenceOrder = transcript.getSequenceOrder();
+        this.timeLabel = transcript.getTimeLabel();  // 메서드로 생성
+        this.isDeleted = transcript.isDeleted();
+        this.createdAt = transcript.getCreatedAt();
+        this.updatedAt = transcript.getUpdatedAt();
+    }
+}

--- a/src/main/java/com/dialog/transcript/repository/TranscriptRepository.java
+++ b/src/main/java/com/dialog/transcript/repository/TranscriptRepository.java
@@ -1,0 +1,24 @@
+package com.dialog.transcript.repository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import com.dialog.transcript.domain.Transcript;
+
+public interface TranscriptRepository extends JpaRepository<Transcript, Long> {
+
+    // Meeting ID로 모든 Transcript 조회 (순서대로)
+    @Query("SELECT t FROM Transcript t WHERE t.meeting.id = :meetingId ORDER BY t.sequenceOrder ASC")
+    List<Transcript> findByMeetingIdOrderBySequenceOrder(@Param("meetingId") Long meetingId);
+    
+    // Meeting ID로 Transcript 존재 여부 확인
+    boolean existsByMeetingId(Long meetingId);
+    
+    // Meeting ID로 Transcript 삭제
+    void deleteByMeetingId(Long meetingId);
+    
+    // 특정 화자의 발화만 조회
+    @Query("SELECT t FROM Transcript t WHERE t.meeting.id = :meetingId AND t.speakerId = :speakerId ORDER BY t.sequenceOrder ASC")
+    List<Transcript> findByMeetingIdAndSpeakerId(@Param("meetingId") Long meetingId, @Param("speakerId") String speakerId);
+}

--- a/src/main/java/com/dialog/transcript/service/TranscriptService.java
+++ b/src/main/java/com/dialog/transcript/service/TranscriptService.java
@@ -1,0 +1,144 @@
+package com.dialog.transcript.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import com.dialog.meeting.domain.Meeting;
+import com.dialog.meeting.repository.MeetingRepository;
+import com.dialog.transcript.domain.Transcript;
+import com.dialog.transcript.domain.TranscriptCreateRequestDto;
+import com.dialog.transcript.domain.TranscriptResponseDto;
+import com.dialog.transcript.repository.TranscriptRepository;
+import lombok.RequiredArgsConstructor;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TranscriptService {
+
+    private final TranscriptRepository transcriptRepository;
+    private final MeetingRepository meetingRepository;
+
+    // Transcript 저장 (단일)
+    @Transactional
+    public TranscriptResponseDto saveTranscript(Long meetingId, TranscriptCreateRequestDto requestDto) {
+        Meeting meeting = meetingRepository.findById(meetingId)
+            .orElseThrow(() -> new IllegalArgumentException("회의를 찾을 수 없습니다."));
+
+        Transcript transcript = Transcript.builder()
+            .meeting(meeting)
+            .speakerId(requestDto.getSpeakerId())
+            .speakerName(requestDto.getSpeakerName())
+            .speakerLabel(requestDto.getSpeakerLabel())
+            .text(requestDto.getText())
+            .startTime(requestDto.getStartTime())
+            .endTime(requestDto.getEndTime())
+            .sequenceOrder(requestDto.getSequenceOrder())
+            .isDeleted(false)  // 기본값
+            .build();
+
+        Transcript savedTranscript = transcriptRepository.save(transcript);
+        return new TranscriptResponseDto(savedTranscript);
+    }
+
+    // Transcript 일괄 저장
+    @Transactional
+    public List<TranscriptResponseDto> saveTranscripts(Long meetingId, List<TranscriptCreateRequestDto> requestDtos) {
+        Meeting meeting = meetingRepository.findById(meetingId)
+            .orElseThrow(() -> new IllegalArgumentException("회의를 찾을 수 없습니다."));
+
+        List<Transcript> transcripts = requestDtos.stream()
+            .map(dto -> Transcript.builder()
+                .meeting(meeting)
+                .speakerId(dto.getSpeakerId())
+                .speakerName(dto.getSpeakerName())
+                .speakerLabel(dto.getSpeakerLabel())
+                .text(dto.getText())
+                .startTime(dto.getStartTime())
+                .endTime(dto.getEndTime())
+                .sequenceOrder(dto.getSequenceOrder())
+                .isDeleted(false)  // 기본값
+                .build())
+            .collect(Collectors.toList());
+
+        List<Transcript> savedTranscripts = transcriptRepository.saveAll(transcripts);
+        
+        return savedTranscripts.stream()
+            .map(TranscriptResponseDto::new)
+            .collect(Collectors.toList());
+    }
+
+    // Meeting ID로 모든 Transcript 조회
+    public List<TranscriptResponseDto> getTranscriptsByMeetingId(Long meetingId) {
+        List<Transcript> transcripts = transcriptRepository.findByMeetingIdOrderBySequenceOrder(meetingId);
+        
+        return transcripts.stream()
+            .map(TranscriptResponseDto::new)
+            .collect(Collectors.toList());
+    }
+
+    // 특정 화자의 발화만 조회
+    public List<TranscriptResponseDto> getTranscriptsBySpeaker(Long meetingId, String speakerId) {
+        List<Transcript> transcripts = transcriptRepository.findByMeetingIdAndSpeakerId(meetingId, speakerId);
+        
+        return transcripts.stream()
+            .map(TranscriptResponseDto::new)
+            .collect(Collectors.toList());
+    }
+
+    // Transcript 수정 (텍스트)
+    @Transactional
+    public TranscriptResponseDto updateTranscriptText(Long transcriptId, String newText) {
+        Transcript transcript = transcriptRepository.findById(transcriptId)
+            .orElseThrow(() -> new IllegalArgumentException("Transcript를 찾을 수 없습니다."));
+        
+        transcript.updateText(newText);
+        return new TranscriptResponseDto(transcript);
+    }
+
+    // Transcript 수정 (화자)
+    @Transactional
+    public TranscriptResponseDto updateTranscriptSpeaker(Long transcriptId, String newSpeakerId, String newSpeakerName) {
+        Transcript transcript = transcriptRepository.findById(transcriptId)
+            .orElseThrow(() -> new IllegalArgumentException("Transcript를 찾을 수 없습니다."));
+        
+        transcript.updateSpeaker(newSpeakerId, newSpeakerName);
+        return new TranscriptResponseDto(transcript);
+    }
+
+    // Transcript 삭제 (소프트 삭제)
+    @Transactional
+    public TranscriptResponseDto deleteTranscript(Long transcriptId) {
+        Transcript transcript = transcriptRepository.findById(transcriptId)
+            .orElseThrow(() -> new IllegalArgumentException("Transcript를 찾을 수 없습니다."));
+        
+        transcript.delete();
+        return new TranscriptResponseDto(transcript);
+    }
+
+    // Transcript 복구
+    @Transactional
+    public TranscriptResponseDto restoreTranscript(Long transcriptId) {
+        Transcript transcript = transcriptRepository.findById(transcriptId)
+            .orElseThrow(() -> new IllegalArgumentException("Transcript를 찾을 수 없습니다."));
+        
+        transcript.restore();
+        return new TranscriptResponseDto(transcript);
+    }
+
+    // Transcript 물리 삭제
+    @Transactional
+    public void hardDeleteTranscript(Long transcriptId) {
+        Transcript transcript = transcriptRepository.findById(transcriptId)
+            .orElseThrow(() -> new IllegalArgumentException("Transcript를 찾을 수 없습니다."));
+        
+        transcriptRepository.delete(transcript);
+    }
+
+    // Meeting의 모든 Transcript 삭제
+    @Transactional
+    public void deleteTranscriptsByMeetingId(Long meetingId) {
+        transcriptRepository.deleteByMeetingId(meetingId);
+    }
+}


### PR DESCRIPTION
## **구현 기능 요약**

- 회의 종료 처리와 발화자(Transcript) 저장을 위한 백엔드 전반의 구조 보완
- Meeting 엔티티의 비즈니스 로직 정리 및 Finish 기능 안정화
- Transcript 엔티티 신규 생성 및 관련 CRUD 계층(Service, Repository, DTO) 구현
- Meeting ↔ Transcript 간 연관관계(1:N) 설정 반영

---

## **개발 내역 상세**
**1) Meeting 엔티티 수정**

- complete() 로직에서 상태 검증 강화 (RECORDING → COMPLETED로 정상 전환)
- updateInfo() 내부 유효성 처리 보강
- 회의 종료 시 Transcript 저장 프로세스와 자연스럽게 연동될 수 있도록 구조 정리
- 회의 종료 요청 DTO(MeetingFinishRequestDto) 구조 정비
   → transcript 요청 객체와 연계될 수 있도록 필드 설계

**2) Transcript 엔티티 신규 생성

- @ManyToOne 으로 Meeting과 연관관계 설정 (meeting_id FK)

**3) Transcript 관련 Repository/Service/Controller 구성**

- TranscriptRepository.java

기본 CRUD 메서드 제공
findByMeetingId() 추가

- TranscriptService.java

Transcript 생성(Create) 로직 구현
회의 종료 시 여러 transcript 리스트 자동 저장 처리
삭제/수정 업데이트 로직 기본 구현

- DTO 추가
TranscriptCreateRequestDto
TranscriptResponseDto
응답 시 speaker, text, timeline 정보 포함

- TranscriptController.java
회의 상세 페이지에서 transcripts 조회 API 추가 (GET /api/transcripts/{meetingId})
테스트용 생성 API 임시 제공 (필요 시 제거 예정)

**4) Meeting 종료 API 연동 흐름 구축**

- /api/meetings/{id}/finish 로직 수정
Meeting 상태 완료 처리
외부 서비스(FastAPI diarization → JS → Spring)의 transcript 목록을 받아 저장
저장 이후 완성된 회의 상세 정보를 반환하도록 구조 개선

---

## **검증 방법**

1. 회의 종료(end) API 테스트

- POST /api/meetings/{id}/finish
- Request Body에 transcript 배열 포함
- DB에 meeting.status 가 COMPLETED로 정상 변경
- transcript 테이블에 N개의 row가 정상 생성되는지 확인

2. Transcript 조회 API 테스트

- GET /api/transcripts/{meetingId}
- 저장된 transcript 리스트가 시간 순으로 반환되는지 검증

3. 연관관계 테스트

- meeting 삭제 시 transcript 자동 삭제(CASCADE) 되는지 확인
- meeting 상세 조회 시 transcript 호출 흐름 정상 확인

---

## **추가 개선 / TODO**

- 발화자 이름 자동 매핑 로직 (spk-1 → 실제 이름) 정교화
- 회의 종료 이후 요약(summary) 및 키워드 추출 로직과 transcript 통합
- transcript 수정 기능 추가(Soft delete 적용 여부 논의 필요)
- diarization 분석 결과와 transcript 저장 흐름 일원화
