### PR TITLE
feat: [BE] 캘린더/홈 데이터 불일치 및 캘린더 비동기 로딩 오류 해결

### DIFF
--- a/src/main/java/com/dialog/calendarevent/controller/CalendarEventController.java
+++ b/src/main/java/com/dialog/calendarevent/controller/CalendarEventController.java
@@ -62,8 +62,7 @@ public class CalendarEventController {
 		if (principal == null) {
 			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
 		}
-		if (request == null || request.getEventData() == null) {
-			// 400 Bad Request를 유발 (GlobalExceptionHandler가 처리)
+		if (request == null || request.getEventData() == null) {		
 			throw new IllegalArgumentException("이벤트 데이터가 비어있습니다.");
 		}
 

--- a/src/main/java/com/dialog/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/dialog/meeting/repository/MeetingRepository.java
@@ -2,6 +2,7 @@ package com.dialog.meeting.repository;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -28,4 +29,7 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
 	// 어제 생성한 회의 수
 	@Query(value = "SELECT COUNT(*) FROM meeting WHERE created_at BETWEEN :start AND :end", nativeQuery = true)
 	long countYesterdayCreatedMeetings(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+
+	List<Meeting> findAllByScheduledAtBetween(LocalDateTime startDateTime, LocalDateTime endDateTime);	
+	
 }


### PR DESCRIPTION
## **구현 기능 요약**
- 백엔드 API 통합 (GET /api/calendar/events): '홈'과 '캘린더' 페이지 간의 데이터 불일치 문제를 근본적으로 해결
---

## **개발 내역 상세**
* MeetingRepository.java
   - Meeting 테이블을 scheduledAt 기준으로 날짜 범위 조회가 가능하도록 findAllByScheduledAtBetween(start, end) 메소드 추가
* CalendarEventService.java
   - MeetingRepository를 주입
   - getEventsByDateRange 메소드 로직 수정 [구글 회의] + [DB Task] + [DB Meeting] 3가지 데이터를 모두 조회 finalEvents.addAll(...)로 통합하여 반환하도록 수정
   - Meeting 객체를 CalendarEventResponse.builder()를 사용하여 DTO로 변환
---

## **검증 방법**
1. (백엔드) Spring 서버를 재시작합니다.

2. (데이터 준비) (선택) meeting 테이블에 테스트용 'DB 회의' 데이터를 1~2건 추가합니다. (예: '2025-11-14' 날짜)

3. [캘린더 통합 검증] calendar.html 접속 -> 11월 14일 클릭 시, [구글 회의]와 [DB 회의]가 팝업과 사이드바에 모두 표시되는지 확인합니다.

4. [홈 화면 통합 검증] home.html 접속 -> '최근 회의' 목록에 11월 14일자 [DB 회의]가 표시되는지 확인합니다.

5. [홈 화면 클릭 검증] '최근 회의' 목록의 제목 클릭 시 calendar.html?date=2025-11-14로 이동하는지 확인합니다.

6. [비동기 오류 검증] 브라우저에 calendar.html?date=2025-11-14 URL을 직접 입력하여 접속했을 때, 팝업(오버레이)에 회의 목록이 즉시 표시되는지 확인합니다. (데이터가 비어있지 않아야 함)

7. [미연동 검증] (시크릿 모드 등) 구글 연동을 하지 않은 상태로 home.html 접속 시, '최근 회의' 목록에 [DB 회의]가 정상적으로 표시되는지 확인합니다.

---
