### PR TITLE
feat: [BE] 비밀번호 찾기 이메일 전송 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -320,3 +320,4 @@ src/main/java/com/dialog/googleauth/
 !src/main/java/com/dialog/googleauth/
 src/main/java/com/dialog/exception/
 !src/main/java/com/dialog/exception/
+!src/main/java/com/dialog/email/service/

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,9 @@ dependencies {
 	implementation 'com.fasterxml.jackson.core:jackson-core:2.17.2'
 	implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.2'
 	implementation 'com.fasterxml.jackson.core:jackson-annotations:2.17.2'
+	
+	// SMTP 관련 의존성 추가
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dialog/email/service/EmailService.java
+++ b/src/main/java/com/dialog/email/service/EmailService.java
@@ -1,0 +1,23 @@
+package com.dialog.email.service;
+
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+	
+    private final JavaMailSender mailSender;
+    
+    public void sendPasswordResetEmail(String toEmail, String resetUrl) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(toEmail);
+        message.setSubject("비밀번호 재설정 안내");
+        message.setText("비밀번호 재설정을 위해 아래 링크를 클릭하세요:\n" + resetUrl + "\n\n유효시간은 1시간입니다.");
+        mailSender.send(message);
+    }
+}

--- a/src/main/java/com/dialog/security/SecurityConfigJWT.java
+++ b/src/main/java/com/dialog/security/SecurityConfigJWT.java
@@ -58,7 +58,8 @@ public class SecurityConfigJWT {
             
             // 5. 권한 설정: 지정된 URL만 무인증 접근 가능, 기타는 인증 필요
            .authorizeHttpRequests(auth -> auth
-    		   .requestMatchers("/api/auth/signup", "/api/auth/login", "/api/auth/me", "/api/reissue").permitAll()
+    		   .requestMatchers("/api/auth/signup", "/api/auth/login", "/api/auth/me", "/api/reissue", 
+    				   "/api/auth/forgotPassword", "/api/auth/resetPassword").permitAll()
     		   // 추후 스프링 내부에서 css, js, images 사용시 주석 해제후 사용
 //    		   .requestMatchers("/css/**",
 //    				   "/js/**", "/images/**").permitAll()

--- a/src/main/java/com/dialog/user/controller/MeetUserController.java
+++ b/src/main/java/com/dialog/user/controller/MeetUserController.java
@@ -29,9 +29,12 @@ import com.dialog.security.oauth2.SocialUserInfo;
 import com.dialog.security.oauth2.SocialUserInfoFactory;
 import com.dialog.token.domain.RefreshTokenDto;
 import com.dialog.token.service.RefreshTokenServiceImpl;
+import com.dialog.user.domain.ForgotPasswordRequestDTO;
 import com.dialog.user.domain.LoginDto;
 import com.dialog.user.domain.MeetUser;
 import com.dialog.user.domain.MeetUserDto;
+import com.dialog.user.domain.ResetPasswordRequestDTO;
+import com.dialog.user.domain.UserApiResponseDTO;
 import com.dialog.user.domain.UserSettingsUpdateDto;
 import com.dialog.user.service.MeetuserService;
 
@@ -134,5 +137,19 @@ public class MeetUserController {
 
         // 성공 메시지를 포함한 HTTP 200 OK 응답 반환
         return ResponseEntity.ok(Map.of("success", true, "message", "개인정보가 성공적으로 저장되었습니다."));
+    }
+    
+    // 비밀번호 재설정 메일 발송 요청
+    @PostMapping("/api/auth/forgotPassword")
+    public ResponseEntity<UserApiResponseDTO> forgotPassword(@Valid @RequestBody ForgotPasswordRequestDTO request) {
+        meetuserService.sendResetPasswordEmail(request.getEmail());
+        return ResponseEntity.ok(new UserApiResponseDTO(true, "비밀번호 재설정 이메일이 발송되었습니다."));
+    }
+
+    // 비밀번호 재설정 (토큰검증 + 비밀번호 변경)
+    @PostMapping("/api/auth/resetPassword")
+    public ResponseEntity<UserApiResponseDTO> resetPassword(@Valid @RequestBody ResetPasswordRequestDTO request) {
+        meetuserService.resetPassword(request.getToken(), request.getNewPassword());
+        return ResponseEntity.ok(new UserApiResponseDTO(true, "비밀번호가 성공적으로 변경되었습니다."));
     }
 }

--- a/src/main/java/com/dialog/user/domain/ForgotPasswordRequestDTO.java
+++ b/src/main/java/com/dialog/user/domain/ForgotPasswordRequestDTO.java
@@ -1,0 +1,14 @@
+package com.dialog.user.domain;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ForgotPasswordRequestDTO {
+    @NotBlank(message = "이메일은 필수 입력값입니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    private String email;
+}

--- a/src/main/java/com/dialog/user/domain/MeetUser.java
+++ b/src/main/java/com/dialog/user/domain/MeetUser.java
@@ -101,6 +101,14 @@ public class MeetUser {
     // 유저 권한 추가
     @Enumerated(EnumType.STRING)
     private Role role;
+    
+    // 비밀번호 재설정 추가
+    @Column(name = "reset_password_token", length = 255)
+    private String resetPasswordToken;
+
+    // 토큰 검사 추가
+    @Column(name = "reset_token_expires_at")
+    private LocalDateTime resetTokenExpiresAt;
 
 
     //  JPA를 위한 기본 생성자.
@@ -155,5 +163,20 @@ public class MeetUser {
       this.job = job;
       this.position = position;
    }
+   
+   
+   public void setResetPasswordToken(String token, LocalDateTime expiresAt) {
+	    this.resetPasswordToken = token;
+	    this.resetTokenExpiresAt = expiresAt;
+	}
+
+	public void clearResetPasswordToken() {
+	    this.resetPasswordToken = null;
+	    this.resetTokenExpiresAt = null;
+	}
+
+	public boolean isResetTokenValid() {
+	    return resetPasswordToken != null && resetTokenExpiresAt != null && resetTokenExpiresAt.isAfter(LocalDateTime.now());
+	}
 
 }

--- a/src/main/java/com/dialog/user/domain/ResetPasswordRequestDTO.java
+++ b/src/main/java/com/dialog/user/domain/ResetPasswordRequestDTO.java
@@ -1,0 +1,18 @@
+package com.dialog.user.domain;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ResetPasswordRequestDTO {
+
+    @NotBlank(message = "토큰은 필수입니다.")
+    private String token;
+
+    @NotBlank(message = "새 비밀번호는 필수입니다.")
+    @Size(min = 12, max = 20, message = "비밀번호는 12자 이상 20자 이하로 입력해주세요.")
+    private String newPassword;
+}

--- a/src/main/java/com/dialog/user/domain/UserApiResponseDTO.java
+++ b/src/main/java/com/dialog/user/domain/UserApiResponseDTO.java
@@ -1,0 +1,11 @@
+package com.dialog.user.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserApiResponseDTO {
+    private boolean success;
+    private String message;
+}

--- a/src/main/java/com/dialog/user/repository/MeetUserRepository.java
+++ b/src/main/java/com/dialog/user/repository/MeetUserRepository.java
@@ -33,5 +33,7 @@ public interface MeetUserRepository extends JpaRepository<MeetUser, Long> {
     // 어제 가입자 수 - 범위 검색
     @Query(value = "SELECT COUNT(*) FROM user WHERE created_at BETWEEN :start AND :end", nativeQuery = true)
     long countYesterdayRegisteredUsers(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+
+	Optional<MeetUser> findByResetPasswordToken(String resetPasswordToken);
     
 }


### PR DESCRIPTION
## **구현 기능 요약**
* 사용자가 비밀번호를 찾아야 하는 경우 이메일을 발송하여 재 설정 URL을 보내 비밀번호 재 설정 할 수 있도록 구현
* gitignore 설정 email.service 예외추가
* 시큐리티 필터체인 내부 요청 추가

---

## **개발 내역 상세**
*  이메일 발송요청 DTO 생성
*  비밀번호 재설정 응답 DTO 생성
*  유저 엔티티 비밀번호 재설정, 토큰 컬럼 추가
*  유저 엔티티 내부 비밀번호 초기화 토큰 발급 메서드 작성
*  유저 엔티티 내부 비밀번호 초기화 토큰 삭제 메서드 작성
*  유저 엔티티 내부  비밀번호 초기화 토큰 유효성 검사 메서드 작성
*  유저 Repository 에서 비밀번호 초기화 토큰 조회 로직 추가
*  이메일 서비스 JavaMailSender 사용하여 메일 발송 메서드 추가
*  build.grdle 의존성 추가
*  application-local.yml SMTP 관련 url 및 설정 추가
* 유저 서비스단 에서 비밀번호 초기화 메서드 추가 컨트롤러에서 호출하여 사용
* 유저 서비스단 에서 비밀번호 초기화 이메일 발송 메서드 추가 컨트롤러에서 호출하여 사용
* 시큐리티 필터체인 내부 권한 설정 부분 로그인 안한 사용자 forgotPassword, resetPassword 요청 보낼수 있도록 허용
---

## **검증 방법**
1.  **Postman**으로 `POST /api/auth/forgotPassword` 요청 시 설정한 이메일로 비밀번호 재설정 URL 발송되는지 확인
2.  해당 URL 의 토큰을 **Postman**으로 `POST /api/auth/resetPassword 요청 시 재설정 한 비밀 번호로 변경되는지 확인
3. login.html 에서 로그인 시 변경 한 비밀번호로 정상적으로 로그인 되는지 확인.

---

## **추가 개선 / TODO**
* 프론트단 에서 처리 할수 있는 js 코드 및 html 구현
