### PR TITLE
feat: [BE] FastAPI 챗봇 서버 연동 (회의록 검색/FAQ)

### DIFF
--- a/src/main/java/com/dialog/AppConfig.java
+++ b/src/main/java/com/dialog/AppConfig.java
@@ -7,7 +7,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
-
+import org.springframework.web.client.RestTemplate;  // HTTP 통신용 클라이언트
 
 @Configuration
 public class AppConfig {
@@ -28,6 +28,13 @@ public class AppConfig {
 	            })
 	    );
 	    return resolver;
+	}
+	
+	// HTTP 통신용 클라이언트
+	// Python FastAPI(포트 8000)와 통신하여 챗봇 요청 중계
+	@Bean
+	public RestTemplate restTemplate() {
+	    return new RestTemplate();
 	}
 	
 }

--- a/src/main/java/com/dialog/chatbot/ChatbotController.java
+++ b/src/main/java/com/dialog/chatbot/ChatbotController.java
@@ -1,0 +1,118 @@
+package com.dialog.chatbot;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.RestTemplate;
+import com.dialog.user.service.CustomUserDetails;
+import java.util.Map;
+import com.dialog.user.domain.MeetUser;
+
+@RestController
+@RequestMapping("/api/chatbot")
+@CrossOrigin(origins = "http://localhost:5500", allowCredentials = "true")
+public class ChatbotController {
+    
+    @Value("${fastapi.base-url:http://localhost:8000}")
+    private String fastApiBaseUrl;
+    
+    private final RestTemplate restTemplate;
+    
+    @Autowired
+    public ChatbotController(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+    
+    // 회의록 검색 챗봇 (Python으로 전달)
+    @PostMapping("/search")
+    public ResponseEntity<String> searchChat(  // [수정] Map → String
+            @RequestBody Map<String, Object> request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        
+        System.out.println("🔹 [ChatBot] 요청 시작");
+        
+        if (userDetails != null) {
+            MeetUser meetUser = userDetails.getMeetUser();
+            
+            Long userId = meetUser.getId();
+            String job = meetUser.getJob() != null 
+                ? meetUser.getJob().name() 
+                : "NONE";
+            String position = meetUser.getPosition() != null 
+                ? meetUser.getPosition().name() 
+                : "NONE";
+            String userName = meetUser.getName();
+            
+            request.put("user_id", userId);
+            request.put("user_job", job);
+            request.put("user_position", position);
+            request.put("user_name", userName);
+            
+            System.out.println("[ChatBot] User: " + userName + " (ID: " + userId + ", Job: " + job + ", Position: " + position + ")");
+        }
+        
+        String url = fastApiBaseUrl + "/api/chat";
+        System.out.println("[ChatBot] 전송 데이터: " + request);
+        
+        try {
+            ResponseEntity<String> response = restTemplate.postForEntity(url, request, String.class);
+            System.out.println("[ChatBot] Python 응답 성공");
+            
+            return ResponseEntity.ok()
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(response.getBody());
+            
+        } catch (Exception e) {
+            System.err.println("[ChatBot] Python 호출 실패: " + e.getMessage());
+            e.printStackTrace();
+            throw e;
+        }
+    }
+    
+    
+    // FAQ 챗봇 (Python으로 전달)
+    @PostMapping("/faq")
+    public ResponseEntity<String> faqChat(  // [수정] Map → String
+            @RequestBody Map<String, Object> request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        
+        System.out.println("[FAQ] 요청 시작");
+        
+        if (userDetails != null) {
+            MeetUser meetUser = userDetails.getMeetUser();
+            
+            Long userId = meetUser.getId();
+            String job = meetUser.getJob() != null 
+                ? meetUser.getJob().name() 
+                : "NONE";
+            String position = meetUser.getPosition() != null 
+                ? meetUser.getPosition().name() 
+                : "NONE";
+            String userName = meetUser.getName();
+            
+            request.put("user_id", userId);
+            request.put("user_job", job);
+            request.put("user_position", position);
+            request.put("user_name", userName);
+            
+            System.out.println("[FAQ] User: " + userName + " (ID: " + userId + ", Job: " + job + ", Position: " + position + ")");
+        }
+        
+        String url = fastApiBaseUrl + "/api/faq";
+        System.out.println("[FAQ] 전송 데이터: " + request);
+        
+        try {
+            ResponseEntity<String> response = restTemplate.postForEntity(url, request, String.class);
+            System.out.println("[FAQ] Python 응답 성공");
+            return ResponseEntity.ok(response.getBody());
+            
+        } catch (Exception e) {
+            System.err.println("[FAQ] Python 호출 실패: " + e.getMessage());
+            e.printStackTrace();
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/dialog/user/service/CustomUserDetails.java
+++ b/src/main/java/com/dialog/user/service/CustomUserDetails.java
@@ -16,6 +16,10 @@ public class CustomUserDetails implements UserDetails {
     public CustomUserDetails(MeetUser user) {
         this.user = user;
     }
+    
+    public MeetUser getMeetUser() {
+        return this.user;
+    }
 
     public Long getId() {
         return user.getId();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,3 +49,14 @@ logging:
   level:
     com.dialog.security.jwt: DEBUG
     com.dialog.security.oauth2: DEBUG
+
+# Python FastAPI 연결 설정
+fastapi:
+  base-url: http://localhost:8000
+
+# OAuth2 리다이렉트 URI 설정
+app:
+  oauth2:
+    fail-uri: http://localhost:8080/login?error=true
+    success-uri: http://localhost:8080/dashboard
+    redirect-uri: http://localhost:8080/oauth2/redirect


### PR DESCRIPTION
## **구현 기능 요약**
Spring Boot와 FastAPI 챗봇 서버를 연결하여 사용자 인증 정보를 포함한 회의록 검색 및 FAQ 기능을 제공합니다.

---

## **개발 내역 상세**
* **`ChatbotController` 클래스 신규 생성:** FastAPI 서버로 요청을 중계하는 2개의 엔드포인트 구현
  - `/api/chatbot/search` - 회의록 검색 챗봇
  - `/api/chatbot/faq` - FAQ 챗봇
  - `@AuthenticationPrincipal`로 현재 로그인 사용자 정보 자동 주입
  - `user_id`, `user_job`, `user_position`, `user_name`을 요청 body에 추가하여 FastAPI로 전달
* **`CustomUserDetails` 수정:** `getMeetUser()` 메서드 추가로 Controller에서 `MeetUser` 엔티티 직접 접근 가능
* **`AppConfig` 수정:** `RestTemplate` 빈 등록으로 FastAPI 서버와 HTTP 통신 지원
* **FastAPI 서버 URL 설정:** `application.properties`의 `fastapi.base-url` 속성 사용 (기본값: `http://localhost:8000`)

---

## **검증 방법**
1. Spring Boot 서버(`localhost:8080`)와 FastAPI 서버(`localhost:8000`) 실행
2. 로그인 후 프론트엔드 또는 **Postman**으로 `POST /api/chatbot/search` 요청 시 응답이 정상적으로 반환되는지 확인
3. Console 로그에서 사용자 정보가 정상 출력되는지 확인:
   ```
   🔹 [ChatBot] 요청 시작
   [ChatBot] User: 장문선 (ID: 1, Job: BACKEND_DEVELOPER, Position: STAFF)
   [ChatBot] Python 응답 성공
   ```
4. FastAPI 서버 로그에서 `user_id`, `user_job`, `user_position`, `user_name`이 포함된 요청이 수신되는지 확인

---

## **추가 개선 / TODO**
* **다음 작업:** 프론트엔드 챗봇 UI와의 완전한 통합 테스트 필요
* **개선 사항:** 현재 `Job`과 `Position`이 `null`인 경우 `"NONE"`으로 처리하는데, 기본값 정책 확인 필요
```