### PR TITLE
feat: [BE] 엔티티 추가

### DIFF
--- a/src/main/java/com/dialog/calendarevent/domain/CalendarEvent.java
+++ b/src/main/java/com/dialog/calendarevent/domain/CalendarEvent.java
@@ -2,6 +2,9 @@ package com.dialog.calendarevent.domain;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+
+import com.dialog.meeting.domain.Meeting;
+
 import java.time.LocalDateTime; // 필요 시 사용
 
 import jakarta.persistence.*;
@@ -30,6 +33,7 @@ public class CalendarEvent {
 	private LocalDate eventDate;
 
 	// 시간이 있는 일정일 경우 사용
+	@Column(nullable = true)
 	private LocalTime eventTime;
 
 	@Enumerated(EnumType.STRING)
@@ -39,39 +43,43 @@ public class CalendarEvent {
 	// 중요 표시 (DB: TINYINT(1) / Java: boolean)
 	@Column(nullable = false)
 	private boolean isImportant;
-	
-	@Column(nullable = false)
-    private boolean isCompleted = false;
 
-	// ------------------ 관계 필드 ------------------
-	private Long taskId;
-	private Long meetingId;
+	@Column(nullable = false)
+	private boolean isCompleted = false;
+
+	// 내부 Task와 연결 (내부 일정)
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "task_id")
+	private Todo task;
+
+	// 내부 Meeting과 연결 (내부 회의)
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "meeting_id")
+	private Meeting meeting;
+
 	private String googleEventId;
 
 	// 생성/수정 시간 필드 (DB 테이블에 created_at이 있으므로 필요)
 	@Column(nullable = false, updatable = false)
 	private LocalDateTime createdAt;
 
-	// ------------------ 1. Builder 패턴을 사용한 생성자 ------------------
 	@Builder
 	public CalendarEvent(Long userId, String title, LocalDate eventDate, LocalTime eventTime, EventType eventType,
-			boolean isImportant, Long taskId, Long meetingId, String googleEventId) {
+			boolean isImportant, Todo task, Meeting meeting, String googleEventId) { // <-- 여기 파라미터 타입 변경
 		this.userId = userId;
 		this.title = title;
 		this.eventDate = eventDate;
 		this.eventTime = eventTime;
 		this.eventType = eventType;
 		this.isImportant = isImportant;
-		this.taskId = taskId;
-		this.meetingId = meetingId;
+
+		this.task = task;
+		this.meeting = meeting;
+
 		this.googleEventId = googleEventId;
 		this.createdAt = LocalDateTime.now();
 	}
 
-	// ------------------ 3. 비즈니스 로직 기반 업데이트 메서드 ------------------
-	/**
-	 * 일정 제목, 날짜, 타입 등 핵심 내용을 업데이트
-	 */
 	public void updateEventDetails(String title, LocalDate eventDate, LocalTime eventTime, EventType eventType) {
 		this.title = title;
 		this.eventDate = eventDate;
@@ -82,8 +90,8 @@ public class CalendarEvent {
 	public void toggleImportance() {
 		this.isImportant = !this.isImportant;
 	}
-	
+
 	public void setIsCompleted(boolean completed) {
-        this.isCompleted = completed;
-    }
+		this.isCompleted = completed;
+	}
 }

--- a/src/main/java/com/dialog/calendarevent/domain/CalendarEventResponse.java
+++ b/src/main/java/com/dialog/calendarevent/domain/CalendarEventResponse.java
@@ -43,10 +43,10 @@ public class CalendarEventResponse {
 		}
 
 		String sourceId = null;
-		if (entity.getEventType() == EventType.TASK && entity.getTaskId() != null) {
-			sourceId = entity.getTaskId().toString();
-		} else if (entity.getEventType() == EventType.MEETING && entity.getMeetingId() != null) {
-			sourceId = entity.getMeetingId().toString();
+		if (entity.getEventType() == EventType.TASK && entity.getTask() != null) {
+			sourceId = entity.getTask().toString();
+		} else if (entity.getEventType() == EventType.MEETING && entity.getMeeting() != null) {
+			sourceId = entity.getMeeting().toString();
 		} else if (entity.getGoogleEventId() != null) {
 			sourceId = entity.getGoogleEventId();
 		}

--- a/src/main/java/com/dialog/calendarevent/domain/Todo.java
+++ b/src/main/java/com/dialog/calendarevent/domain/Todo.java
@@ -1,0 +1,106 @@
+package com.dialog.calendarevent.domain;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import com.dialog.meeting.domain.Meeting;
+import com.dialog.user.domain.MeetUser;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "task") // 테이블명 명시
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Todo {
+
+    // 1. id (PK, BIGINT, AI)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 2. title (VARCHAR(500), NN)
+    @Column(nullable = false, length = 500)
+    private String title;
+
+    // 3. description (TEXT)
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    // 4. user_id (FK, BIGINT, NN) - 담당자 아님, 소유자(작성자)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private MeetUser user;
+
+    // 5. assignee_name (VARCHAR(100)) - 실제 수행 담당자 이름 (선택)
+    @Column(name = "assignee_name", length = 100)
+    private String assigneeName;
+
+    // 6. due_date (DATE)
+    @Column(name = "due_date")
+    private LocalDate dueDate;
+
+    // 7. status (ENUM, NN, Default: 'TODO')
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default // 빌더 패턴 사용 시 기본값 적용을 위해 필수
+    private TodoStatus status = TodoStatus.TODO;
+
+    // 8. meeting_id (FK, BIGINT) - 회의에서 파생된 경우 연결 (Nullable)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "meeting_id")
+    private Meeting meeting;
+
+    // 9. source (ENUM, NN, Default: 'MANUAL')
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private TodoSource source = TodoSource.MANUAL;
+
+    // 10. extracted_from_text (TEXT) - AI 추출 시 원문 문장
+    @Lob
+    @Column(name = "extracted_from_text", columnDefinition = "TEXT")
+    private String extractedFromText;
+
+    // 11. created_at (TIMESTAMP, NN, Default: NOW)
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    // 12. updated_at (TIMESTAMP, NN, Default: NOW ON UPDATE)
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    // --- 편의 메서드 (비즈니스 로직) ---
+
+    // 정보 수정
+    public void updateInfo(String title, String description, LocalDate dueDate, String assigneeName) {
+        if (title != null) this.title = title;
+        if (description != null) this.description = description;
+        if (dueDate != null) this.dueDate = dueDate;
+        if (assigneeName != null) this.assigneeName = assigneeName;
+    }
+
+    // 완료 처리
+    public void complete() {
+        this.status = TodoStatus.COMPLETED;
+    }
+
+    // 미완료 처리 (취소)
+    public void markAsTodo() {
+        this.status = TodoStatus.TODO;
+    }
+    
+    // 상태 토글 (완료 <-> 미완료)
+    public void toggleStatus() {
+        if (this.status == TodoStatus.COMPLETED) {
+            this.status = TodoStatus.TODO;
+        } else {
+            this.status = TodoStatus.COMPLETED;
+        }
+    }
+}

--- a/src/main/java/com/dialog/calendarevent/domain/TodoSource.java
+++ b/src/main/java/com/dialog/calendarevent/domain/TodoSource.java
@@ -1,0 +1,6 @@
+package com.dialog.calendarevent.domain;
+
+public enum TodoSource {
+	AI_EXTRACTED, // AI가 회의록에서 자동 추출
+    MANUAL        // 사용자가 직접 등록
+}

--- a/src/main/java/com/dialog/calendarevent/domain/TodoStatus.java
+++ b/src/main/java/com/dialog/calendarevent/domain/TodoStatus.java
@@ -1,0 +1,6 @@
+package com.dialog.calendarevent.domain;
+
+public enum TodoStatus {
+	TODO,
+    COMPLETED
+}

--- a/src/main/java/com/dialog/calendarevent/repository/TodoRepository.java
+++ b/src/main/java/com/dialog/calendarevent/repository/TodoRepository.java
@@ -1,0 +1,8 @@
+package com.dialog.calendarevent.repository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.dialog.calendarevent.domain.Todo;
+
+public interface TodoRepository extends JpaRepository<Todo, Long> {
+
+}

--- a/src/main/java/com/dialog/meeting/service/MeetingService.java
+++ b/src/main/java/com/dialog/meeting/service/MeetingService.java
@@ -9,6 +9,9 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.dialog.calendarevent.domain.CalendarEvent;
+import com.dialog.calendarevent.domain.EventType;
+import com.dialog.calendarevent.repository.CalendarEventRepository;
 import com.dialog.keyword.domain.Keyword;
 import com.dialog.keyword.repository.KeywordRepository;
 import com.dialog.meeting.domain.Meeting;
@@ -38,7 +41,7 @@ public class MeetingService {
 	private final KeywordRepository keywordRepository;
 	private final RecordingRepository recordingRepository;
 	private final TranscriptRepository transcriptRepository;
-
+	private final CalendarEventRepository calendarEventRepository;
 	// 회의 생성
 	@Transactional
 	public MeetingCreateResponseDto createMeeting(MeetingCreateRequestDto requestDto, Long hostUserId)
@@ -83,6 +86,18 @@ public class MeetingService {
 			meetingRepository.save(savedMeeting);
 		}
 
+		CalendarEvent calendarEvent = CalendarEvent.builder()
+                .userId(hostUser.getId())
+                .title(savedMeeting.getTitle())       
+                .eventDate(savedMeeting.getScheduledAt().toLocalDate())
+                .eventTime(savedMeeting.getScheduledAt().toLocalTime()) 
+                .eventType(EventType.MEETING)
+                .isImportant(savedMeeting.isImportant()) // 중요도 동기화
+                .meeting(savedMeeting)                   
+                .build();
+
+        calendarEventRepository.save(calendarEvent);
+        
 		// 6. 응답 반환 세팅 (이름/키워드 스트링값만 추출)
 		List<String> participantIds = new ArrayList<>();
 		for (Participant participant : participantEntities) {


### PR DESCRIPTION
## **구현 기능 요약**
1. 데이터 정합성 확보: Google 캘린더 연동 시 발생하는 Timezone 파싱 오류 해결 및 DB 저장 로직 안정화.
2. 아키텍처 개선: Todo 엔티티 분리 및 CalendarEvent와의 연관관계(JPA) 재설계로 유지보수성 향상.
3. 기능 고도화: 회의 중요도(isImportant) 관리 방식을 키워드 기반에서 컬럼 기반으로 정규화 및 Admin 삭제 기능 구현.
4. 자동 동기화: 내부 회의 생성 시 캘린더(CalendarEvent) 자동 등록 로직 구현.
---

## **개발 내역 상세**
* Admin 회의 삭제 API (DELETE /api/admin/meetings/{meetingId}) 구현
  - FK 제약 조건 해결을 위해 하위 엔티티(Participant) 선행 삭제 후 Meeting 삭제 로직 적용.
  - ResourceNotFoundException을 통한 명확한 404 에러 처리.
* 회의 중요도(isImportant) 관리 리팩토링
  - 기존 임시 로직(Keywords 검색)을 폐기하고 Meeting 엔티티에 isImportant 필드 추가.
  - toggleImportance 서비스 로직에 save() 호출 및 return 문을 추가하여 트랜잭션 롤백 문제 해결.
* Google 캘린더 연동 저장 로직 수정 (Timezone 이슈)
  - LocalDateTime이 처리하지 못하는 ISO 포맷(+09:00) 파싱 오류 해결을 위해 ZonedDateTime 도입.
  - CalendarEventService.createCalendarEvent에서 예외 발생 시 원인을 파악할 수 있도록 로그 강화.
* 데이터 모델 구조 개선 (Todo 엔티티 분리)
  - CalendarEvent 내의 단순 ID 필드(taskId, meetingId)를 제거하고 Todo, Meeting 객체와의 JPA 연관관계(@OneToOne, @ManyToOne)로 변경.
  - 독립적인 Todo 엔티티 및 TodoRepository 신규 생성.
* 회의-캘린더 자동 동기화 구현
  - MeetingService.createMeeting 실행 시, CalendarEvent 테이블에도 데이터가 자동 생성되도록 로직 추가 (meeting_id FK 연결).
---

## **검증 방법**
1.  Admin 삭제 검증: 관리자 계정으로 회의 삭제 요청 시 204 No Content 응답 확인 및 DB 내 meeting, participant 테이블 데이터 삭제 확인.

2. 중요도 토글 검증: 캘린더에서 중요(별표) 클릭 후 새로고침 시에도 상태가 유지되는지 확인 (DB is_important 컬럼 값 1 확인).

3. Google 연동 저장 검증: (프론트엔드 API 연결 후) 일정 생성 시 서버 로그에 createCalendarEvent 호출됨 메시지가 뜨는지 확인 및 calendar_event 테이블에 데이터 적재 확인.

4. 내부 회의 연동 검증: '새 회의 만들기' 완료 후 calendar_event 테이블에 meeting_id가 채워진 데이터가 생성되었는지 확인.
---
