### PR TITLE
feat: [BE] 아이디 기억하기 기능 구현, 로그아웃 추가 및 쿠키 관련 코드 리팩토링

### DIFF
--- a/src/main/java/com/dialog/config/AppConfig.java
+++ b/src/main/java/com/dialog/config/AppConfig.java
@@ -1,4 +1,4 @@
-package com.dialog;
+package com.dialog.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/dialog/config/WebConfig.java
+++ b/src/main/java/com/dialog/config/WebConfig.java
@@ -1,4 +1,4 @@
-package com.dialog;
+package com.dialog.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;

--- a/src/main/java/com/dialog/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dialog/global/exception/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package com.dialog;
+package com.dialog.global.exception;
 import java.util.Map;
 
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/dialog/global/utill/CookieUtil.java
+++ b/src/main/java/com/dialog/global/utill/CookieUtil.java
@@ -1,0 +1,61 @@
+package com.dialog.global.utill;
+
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+
+@Component
+public class CookieUtil {
+	
+	// 쿠키 조회 메서드
+    public Cookie getCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (name.equals(cookie.getName())) {
+                    return cookie;
+                }
+            }
+        }
+        return null;
+    }
+
+    // JWT 액세스 토큰 쿠키 생성
+    public Cookie createAccessTokenCookie(String token) {
+        return createCookie("jwt", token, 60 * 60 * 3, true); // 3시간, HttpOnly=true
+    }
+
+    // 리프레시 토큰 쿠키 생성
+    public Cookie createRefreshTokenCookie(String token) {
+        return createCookie("refreshToken", token, 7 * 24 * 60 * 60, true); // 7일, HttpOnly=true
+    }
+
+    // 아이디 기억하기 쿠키 생성 (HttpOnly=false)
+    public Cookie createRememberMeCookie(String email) {
+        return createCookie("savedEmail", email, 60 * 60 * 24, false); // 1일, HttpOnly=false
+    }
+
+
+    // 쿠키 삭제 (HttpOnly=true 인 보안 쿠키용: AccessToken(jwt), refreshToken)
+    public Cookie deleteCookie(String name) {
+        return createCookie(name, null, 0, true); 
+    }
+    
+    // 쿠키 삭제 (HttpOnly 설정을 직접 지정: savedEmail 등) 
+    public Cookie deleteCookie(String name, boolean httpOnly) {
+		return createCookie(name, null, 0, httpOnly);
+	}
+
+    // 내부적으로 사용하는 공통 메서드
+    private Cookie createCookie(String name, String value, int maxAge, boolean httpOnly) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setHttpOnly(httpOnly);
+        cookie.setSecure(false); // 배포(HTTPS) 환경이면 true로 변경 필요
+        cookie.setPath("/");
+        cookie.setMaxAge(maxAge);
+        return cookie;
+    }
+
+
+}

--- a/src/main/java/com/dialog/security/SecurityConfig.java
+++ b/src/main/java/com/dialog/security/SecurityConfig.java
@@ -12,6 +12,7 @@ import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequest
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import com.dialog.global.utill.CookieUtil;
 import com.dialog.security.jwt.JwtAuthenticationFilter;
 import com.dialog.security.jwt.JwtTokenProvider;
 import com.dialog.security.oauth2.OAuth2AuthenticationFailurHandler;
@@ -25,7 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RequiredArgsConstructor
 @Configuration
-public class SecurityConfigJWT {
+public class SecurityConfig {
 
     private final MeetAuthenticationFaliureHandler faliureHandler;              // 폼 로그인 실패 시 처리기
     private final MeetAuthenticationSuccessHandler successHandler;              // 폼 로그인 성공 시 처리기
@@ -34,6 +35,7 @@ public class SecurityConfigJWT {
     private final CustomOAuth2UserService customOAuth2UserService;               // OAuth2UserService 커스텀 구현체
     private final JwtTokenProvider jwtTokenProvider;                             // JWT 토큰 생성/검증기
     private final OAuth2AuthorizationRequestResolver customAuthorizationRequestResolver;
+    private final CookieUtil cookieUtil;
 
     @Value("${app.oauth2.fail-uri}")
     String failUrl;
@@ -86,7 +88,7 @@ public class SecurityConfigJWT {
             .logout(logout -> logout.disable())
             
             // 9. JWT 필터 등록: 폼 로그인 전에 실행되도록 함
-            .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)            
+            .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, cookieUtil), UsernamePasswordAuthenticationFilter.class)            
             // 10. 인증/권한 관련 예외 처리 설정
             .exceptionHandling(ex -> ex
               .authenticationEntryPoint((request, response, authException) -> {

--- a/src/main/java/com/dialog/token/controller/TokenController.java
+++ b/src/main/java/com/dialog/token/controller/TokenController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.dialog.exception.RefreshTokenException;
+import com.dialog.global.utill.CookieUtil;
 import com.dialog.token.service.TokenReissueService;
 
 import jakarta.servlet.http.Cookie;
@@ -20,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 public class TokenController {
    
     private final TokenReissueService tokenReissueService;
+    private final CookieUtil cookieUtil;
 
    
    // 토큰 재발급 메서드
@@ -31,14 +33,10 @@ public class TokenController {
         }
 
         try {
+            // 서비스에서 새로운 Access Token 문자열 받기
             String newAccessToken = tokenReissueService.reissueAccessToken(refreshToken);
-
-            Cookie accessTokenCookie = new Cookie("jwt", newAccessToken);
-            accessTokenCookie.setHttpOnly(true);
-            accessTokenCookie.setSecure(false);
-            accessTokenCookie.setPath("/");
-            accessTokenCookie.setMaxAge(60 * 60); // 1시간
-            response.addCookie(accessTokenCookie);
+            // CookieUtil을 사용하여 쿠키 생성 및 응답에 추가
+            response.addCookie(cookieUtil.createAccessTokenCookie(newAccessToken));
 
             return ResponseEntity.ok("Access token 재발급");
         } catch (RefreshTokenException e) {

--- a/src/main/java/com/dialog/token/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/dialog/token/repository/RefreshTokenRepository.java
@@ -23,6 +23,8 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     // 리프레시 토큰도 삭제해야해서 메서드 추가.
     @Transactional
 	void deleteByUser(MeetUser user);
+
+	void deleteByUserEmail(String email);
     
     
 }

--- a/src/main/java/com/dialog/token/service/RefreshTokenService.java
+++ b/src/main/java/com/dialog/token/service/RefreshTokenService.java
@@ -16,4 +16,7 @@ public interface RefreshTokenService {
     void revokeToken(String token);
 
     void deleteExpiredTokens();
+
+	void deleteByEmail(String email);
+	
 }

--- a/src/main/java/com/dialog/token/service/RefreshTokenServiceImpl.java
+++ b/src/main/java/com/dialog/token/service/RefreshTokenServiceImpl.java
@@ -115,6 +115,13 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
         RefreshToken refreshToken = this.verifyTokenValidity(token);
         return RefreshTokenDto.fromEntity(refreshToken);
     }
+  
+    // User 조회 후 Refresh 토큰 삭제
+    @Override
+    @Transactional
+    public void deleteByEmail(String email) {
+        refreshTokenRepository.deleteByUserEmail(email); 
+    }
     
     
 }

--- a/src/main/java/com/dialog/user/domain/LoginDto.java
+++ b/src/main/java/com/dialog/user/domain/LoginDto.java
@@ -17,4 +17,8 @@ public class LoginDto {
 
     @NotBlank
     private String password;
+    
+    // 아이디 기억하기 체크 여부 추가
+    private boolean rememberId; 
+    
 }


### PR DESCRIPTION
## **구현 기능 요약**
* 아이디 기억하기 기능 구현
* 로그아웃 시 쿠키에 있는 토큰 삭제
* 쿠키 관련 코드 리팩토링

---

## **개발 내역 상세**
* LoginDto 내부 아이디 기억하기 체크 여부 변수 추가 (boolean rememberId)
* MeetUserController 로그인 메서드 내부 아이디 기억하기 기능 추가
* MeetUserController 로그아웃 메서드 추가 
* 기존 app.js 에서 로그아웃 처리 시 HttpOnly=frue 설정 때문에 쿠키 접근 불가 하여 토큰 삭제 안됨
* CookieUtill 클래스 생성 후 쿠키 사용 하는 코드 리팩토링
* 시큐리티 필터 체인 내부 jwt 필터 부분 cookieUtill 추가
* global 패키지 생성 Exception, Utill 패키지 생성하여 프로젝트 구조 세분화

---

## **검증 방법**
1.  서비스 계정 로그인 시 아이디 기억하기 체크 후 로그인
2.  로그아웃 시 이메일 부분 이메일 그대로 있는지 확인
3.  브라우저 개발자 도구(F12) Application -> Cookies -> jwt, RefreshToken 삭제 되는지 확인
4.  saveEmail 은 남아있음

---


