### PR TITLE
feat: [BE] 캘린더 서비스 데이터 정합성 확보 및 Google 연동 모듈 구조 개선

### DIFF
--- a/src/main/java/com/dialog/calendarevent/controller/CalendarEventController.java
+++ b/src/main/java/com/dialog/calendarevent/controller/CalendarEventController.java
@@ -2,9 +2,7 @@ package com.dialog.calendarevent.controller;
 
 import java.security.Principal;
 import java.time.LocalDate;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
@@ -38,7 +36,7 @@ import lombok.extern.log4j.Log4j2;
 public class CalendarEventController {
 
 	private final CalendarEventService calendarEventService;
-	private final SocialTokenService tokenManagerService;	
+	private final SocialTokenService tokenManagerService;
 
 	@GetMapping("/calendar/events")
 	public ResponseEntity<List<CalendarEventResponse>> getEvents(Principal principal, // ResponseEntity<?> ->
@@ -62,7 +60,7 @@ public class CalendarEventController {
 		if (principal == null) {
 			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
 		}
-		if (request == null || request.getEventData() == null) {		
+		if (request == null || request.getEventData() == null) {
 			throw new IllegalArgumentException("이벤트 데이터가 비어있습니다.");
 		}
 
@@ -114,37 +112,34 @@ public class CalendarEventController {
 	}
 
 	@PatchMapping("/calendar/{eventId}/importance")
-    public ResponseEntity<Void> toggleImportance(
-            @PathVariable("eventId") String eventId,
-            Principal principal) {
+	public ResponseEntity<Void> toggleImportance(@PathVariable("eventId") String eventId, Principal principal) {
 
-        if (principal == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        }
-        
-        // 현재 로그인한 사용자 이메일
-        String userEmail = principal.getName();
+		if (principal == null) {
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+		}
 
-        // [중요] 서비스 계층에도 userEmail과 eventId를 전달합니다.
-        calendarEventService.toggleImportance(userEmail, eventId);
+		// 현재 로그인한 사용자 이메일
+		String userEmail = principal.getName();
 
-        return ResponseEntity.ok().build();
-    }
+		// [중요] 서비스 계층에도 userEmail과 eventId를 전달합니다.
+		calendarEventService.toggleImportance(userEmail, eventId);
+
+		return ResponseEntity.ok().build();
+	}
+
 	@PatchMapping("/calendar/events/{eventId}/completion")
-    public ResponseEntity<Void> updateEventCompletion(
-            @PathVariable("eventId") String eventId,
-            @RequestBody EventCompletionRequest request,
-            Principal principal) {
+	public ResponseEntity<Void> updateEventCompletion(@PathVariable("eventId") String eventId,
+			@RequestBody EventCompletionRequest request, Principal principal) {
 
-        if (principal == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        }
-        
-        String userEmail = principal.getName();        
+		if (principal == null) {
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+		}
 
-        calendarEventService.updateCompletionStatus(userEmail, eventId, request.isCompleted());
+		String userEmail = principal.getName();
 
-        return ResponseEntity.ok().build();
-    }
-	
+		calendarEventService.updateCompletionStatus(userEmail, eventId, request.isCompleted());
+
+		return ResponseEntity.ok().build();
+	}
+
 }

--- a/src/main/java/com/dialog/calendarevent/domain/CalendarCreateRequest.java
+++ b/src/main/java/com/dialog/calendarevent/domain/CalendarCreateRequest.java
@@ -17,8 +17,5 @@ public class CalendarCreateRequest {
 	// 1. String 대신 EventType Enum을 사용하여 타입 안전성 확보
 	private EventType eventType; 
 	
-	private boolean isImportant;
-    
-    // 로컬 DB 연결을 위한 ID
-    private Long referenceId; // task_id 또는 meeting_id를 담을 수 있는 범용 필드
+	private boolean isImportant;    
 }

--- a/src/main/java/com/dialog/calendarevent/domain/CalendarEvent.java
+++ b/src/main/java/com/dialog/calendarevent/domain/CalendarEvent.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 
 import com.dialog.meeting.domain.Meeting;
+import com.dialog.todo.domain.Todo;
 
 import java.time.LocalDateTime; // 필요 시 사용
 
@@ -65,17 +66,15 @@ public class CalendarEvent {
 
 	@Builder
 	public CalendarEvent(Long userId, String title, LocalDate eventDate, LocalTime eventTime, EventType eventType,
-			boolean isImportant, Todo task, Meeting meeting, String googleEventId) { // <-- 여기 파라미터 타입 변경
+			boolean isImportant, Todo task, Meeting meeting, String googleEventId) { 
 		this.userId = userId;
 		this.title = title;
 		this.eventDate = eventDate;
 		this.eventTime = eventTime;
 		this.eventType = eventType;
 		this.isImportant = isImportant;
-
 		this.task = task;
 		this.meeting = meeting;
-
 		this.googleEventId = googleEventId;
 		this.createdAt = LocalDateTime.now();
 	}

--- a/src/main/java/com/dialog/calendarevent/domain/CalendarEventResponse.java
+++ b/src/main/java/com/dialog/calendarevent/domain/CalendarEventResponse.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @AllArgsConstructor 
 public class CalendarEventResponse {
 
-	private Long id; // final 제거 확인됨 (Good!)
+	private Long id;
 	private Long userId;
 	private String title;
 
@@ -43,15 +43,16 @@ public class CalendarEventResponse {
 		}
 
 		String sourceId = null;
-		if (entity.getEventType() == EventType.TASK && entity.getTask() != null) {
-			sourceId = entity.getTask().toString();
-		} else if (entity.getEventType() == EventType.MEETING && entity.getMeeting() != null) {
-			sourceId = entity.getMeeting().toString();
-		} else if (entity.getGoogleEventId() != null) {
-			sourceId = entity.getGoogleEventId();
-		}
+	    // 객체 자체가 아니라, 객체의 getId()를 호출해야 합니다.
+	    if (entity.getEventType() == EventType.TASK && entity.getTask() != null) {
+	        sourceId = String.valueOf(entity.getTask().getId()); 
+	    } else if (entity.getEventType() == EventType.MEETING && entity.getMeeting() != null) {
+	        sourceId = String.valueOf(entity.getMeeting().getId());
+	    } else if (entity.getGoogleEventId() != null) {
+	        sourceId = entity.getGoogleEventId();
+	    }
 
-		return CalendarEventResponse.builder().id(entity.getId()).userId(entity.getUserId()).title(entity.getTitle())
+	    return CalendarEventResponse.builder().id(entity.getId()).userId(entity.getUserId()).title(entity.getTitle())
 				.eventDate(entity.getEventDate() != null ? entity.getEventDate().toString() : null)
 				.time(entity.getEventTime()).eventType(entity.getEventType().name()).isImportant(entity.isImportant())
 				.isCompleted(entity.isCompleted()).sourceId(sourceId).googleEventId(entity.getGoogleEventId()).createdAt(entity.getCreatedAt()).build();

--- a/src/main/java/com/dialog/calendarevent/domain/GoogleEventRequestDTO.java
+++ b/src/main/java/com/dialog/calendarevent/domain/GoogleEventRequestDTO.java
@@ -13,7 +13,6 @@ public class GoogleEventRequestDTO {
 	private String summary;
 	private String description;
 
-	// EventDateTimeDTO를 사용하여 start/end 객체를 받습니다.
 	private EventDateTimeDTO start;
 	private EventDateTimeDTO end;
 	private Map<String, Object> eventData;

--- a/src/main/java/com/dialog/calendarevent/domain/GoogleEventResponseDTO.java
+++ b/src/main/java/com/dialog/calendarevent/domain/GoogleEventResponseDTO.java
@@ -33,7 +33,7 @@ public class GoogleEventResponseDTO {
 	private EventDateTimeDTO end;
 
     @JsonProperty("items")
-	private List<GoogleEventResponseDTO> items; // ⭐ 스스로의 리스트를 담도록 변경
+	private List<GoogleEventResponseDTO> items;
 
 	public List<GoogleEventResponseDTO> getItems() {
         return items;

--- a/src/main/java/com/dialog/calendarevent/service/GoogleTokenDto.java
+++ b/src/main/java/com/dialog/calendarevent/service/GoogleTokenDto.java
@@ -15,7 +15,7 @@ public class GoogleTokenDto {
 	private String accessToken;
 
 	@JsonProperty("expires_in")
-	private Long expiresIn; // Long으로 설정하여 Integer 값도 수용 가능하게 처리
+	private Long expiresIn;
 
 	@JsonProperty("scope")
 	private String scope;

--- a/src/main/java/com/dialog/googleauth/controller/GoogleAuthController.java
+++ b/src/main/java/com/dialog/googleauth/controller/GoogleAuthController.java
@@ -1,5 +1,6 @@
 package com.dialog.googleauth.controller;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -22,7 +23,10 @@ import java.util.Map;
 public class GoogleAuthController {
 
     private final GoogleAuthService googleAuthService;
-
+    
+    @Value("${app.frontend-url}")
+    private String frontendUrl;
+    
     @GetMapping("/api/calendar/link/start")
     public ResponseEntity<?> startGoogleAccountLink(Authentication authentication) {
         if (authentication == null || !(authentication.getPrincipal() instanceof UserDetails)) {
@@ -49,13 +53,13 @@ public class GoogleAuthController {
         try {
             userId = Long.parseLong(new String(Base64.getUrlDecoder().decode(state)));
         } catch (Exception e) {
-            response.sendRedirect("/error-page?message=invalid_state");
+        	response.sendRedirect(frontendUrl + "/error.html?message=invalid_state");
             return;
         }
 
         try {
             googleAuthService.exchangeCodeAndSaveToken(userId, code);
-            response.sendRedirect("http://localhost:5500/home.html?link=success");
+            response.sendRedirect(frontendUrl + "/home.html?link=success");
         } catch (UserNotFoundException e) {
             response.sendRedirect("/error-page?message=user_not_found");
         } catch (IOException e) {

--- a/src/main/java/com/dialog/todo/domain/Todo.java
+++ b/src/main/java/com/dialog/todo/domain/Todo.java
@@ -1,4 +1,4 @@
-package com.dialog.calendarevent.domain;
+package com.dialog.todo.domain;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import org.hibernate.annotations.CreationTimestamp;
@@ -74,8 +74,6 @@ public class Todo {
     @UpdateTimestamp
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
-
-    // --- 편의 메서드 (비즈니스 로직) ---
 
     // 정보 수정
     public void updateInfo(String title, String description, LocalDate dueDate, String assigneeName) {

--- a/src/main/java/com/dialog/todo/domain/TodoSource.java
+++ b/src/main/java/com/dialog/todo/domain/TodoSource.java
@@ -1,4 +1,4 @@
-package com.dialog.calendarevent.domain;
+package com.dialog.todo.domain;
 
 public enum TodoSource {
 	AI_EXTRACTED, // AI가 회의록에서 자동 추출

--- a/src/main/java/com/dialog/todo/domain/TodoStatus.java
+++ b/src/main/java/com/dialog/todo/domain/TodoStatus.java
@@ -1,4 +1,4 @@
-package com.dialog.calendarevent.domain;
+package com.dialog.todo.domain;
 
 public enum TodoStatus {
 	TODO,

--- a/src/main/java/com/dialog/todo/repository/TodoRepository.java
+++ b/src/main/java/com/dialog/todo/repository/TodoRepository.java
@@ -1,7 +1,7 @@
-package com.dialog.calendarevent.repository;
+package com.dialog.todo.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.dialog.calendarevent.domain.Todo;
+import com.dialog.todo.domain.Todo;
 
 public interface TodoRepository extends JpaRepository<Todo, Long> {
 


### PR DESCRIPTION
## **구현 기능 요약**
1. 캘린더 서비스 데이터 정합성 확보 및 Google 연동 모듈 구조 개선
2. 새 회의 만들기' 기능 수행 후 캘린더 조회 시, 동일한 회의가 2개씩 중복되어 렌더링되는 문제 개선.
---

## **개발 내역 상세**
* 일정 완료 상태(isCompleted) 저장 로직 수정
  - updateCompletionStatus 서비스 메서드 내에 명시적인 calendarEventRepository.save(event) 호출을 추가하여, 변경된 상태값이 DB에 누락 없이 반영되도록 수정.
* Google API 클라이언트(GoogleCalendarApiClient) 리팩토링
  - 자바 코드 내 박혀있던 구글 API URL 상수를 제거하고 application.yml 설정(google.api.calendar-url)으로 분리.
  - Lombok(@requiredargsconstructor)과 @value 생성자 주입 간의 충돌 문제를 해결하기 위해 수동 생성자 방식으로 변경.

* Google 인증 컨트롤러(GoogleAuthController) 하드코딩 제거
  - 소스 코드 내 하드코딩되어 있던 프론트엔드 URL(http://localhost:5500)을 application-local.yml의 설정 값(app.frontend-url)으로 대체.
  - @value 어노테이션을 통해 환경(Local/Prod)에 따라 유동적으로 리다이렉트 URL이 적용되도록 개선.

* Google 인증 서비스(GoogleAuthService) 로직 안정화 및 리팩토링

  - 구글 재로그인 시 Refresh Token이 null로 반환될 경우, 기존 DB에 저장된 토큰이 덮어씌워지지 않고 유지되도록 수정하여 연동 풀림 현상 방지.
  - 클래스 및 메서드 단위에 @transactional을 명시하여 읽기/쓰기 작업의 데이터 무결성 보장 및 성능 최적화.
  - extractUserId 등 복잡했던 사용자 식별 로직을 불필요한 분기 제거를 통해 명확하게 리팩토링.

* 새 회의 만들기' 기능 수행 후 캘린더 조회 시, 동일한 회의가 2개씩 중복되어 렌더링 되는 문제
  - CalendarEventService.getEventsByDateRange 메서드에서 meetingRepository를 통한 조회 로직 제거
  - 테이블이 모든 내부 회의 정보(Meeting ID와 isImportant 플래그)를 포함하는 통합 뷰(View) 역할을 수행하므로, 해당 테이블만 조회하도록
---

## **검증 방법**
1. 설정 및 안정성 검증 (URL, 토큰, 트랜잭션)
2. application.yml의 프론트엔드 URL 값(예: 5500)을 변경 후, 구글 연동 완료 시 수정된 URL로 리다이렉트되는지 확인합니다.
3. 구글 계정 연동 후, 권한을 해제하지 않고 토큰 만료 후 재로그인 시 에러 없이 성공하는지 확인합니다.
4. 리팩토링된 로직을 거치는 로그인 후, DB 작업 시 오류 없이 정상적으로 데이터가 저장되는지 확인합니다.
5. '새 회의 만들기' 기능을 실행하여 회의를 생성한 후, 캘린더 화면에 해당 회의가 정확히 1개만 표시되는지 확인합니다.
---
