### PR TITLE
feat: [BE] 사용자 직무설정 모달창 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     // 아래는 위에만 있고 아래에는 없어서 추가된 의존성입니다.
     implementation 'com.google.apis:google-api-services-calendar:v3-rev20220715-2.0.0'
     implementation 'com.google.api-client:google-api-client:2.0.0'
-    runtimeOnly 'com.mysql:mysql-connector-j' // 두 목록 모두에 있었으나, 최신 버전을 명시적으로 유지
+    implementation 'com.mysql:mysql-connector-j' // 두 목록 모두에 있었으나, 최신 버전을 명시적으로 유지
     implementation 'com.google.api-client:google-api-client:1.33.0' 
 	implementation 'com.google.oauth-client:google-oauth-client-jetty:1.33.0' 
 	implementation 'com.google.http-client:google-http-client-jackson2:1.39.2' 

--- a/src/main/java/com/dialog/security/oauth2/CustomOAuth2User.java
+++ b/src/main/java/com/dialog/security/oauth2/CustomOAuth2User.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
+import com.dialog.user.domain.Job;
 import com.dialog.user.domain.MeetUser;
 
 
@@ -22,6 +23,10 @@ public class CustomOAuth2User implements OAuth2User {
 	private final String nameAttributeKey;
 	// 내부 도메인 사용자 엔티티
 	private final MeetUser meetuser;
+	
+	public boolean isJobEmpty() {
+        return this.meetuser.getJob() == Job.NONE;
+    }
 
 	// 생성자: 외부 OAuth2 정보와 내부 사용자 엔티티를 함께 묶음
 	public CustomOAuth2User(Collection<? extends GrantedAuthority> authorities, Map<String, Object> attributes,

--- a/src/main/java/com/dialog/user/controller/MeetUserController.java
+++ b/src/main/java/com/dialog/user/controller/MeetUserController.java
@@ -31,6 +31,7 @@ import com.dialog.security.oauth2.SocialUserInfoFactory;
 import com.dialog.token.domain.RefreshTokenDto;
 import com.dialog.token.service.RefreshTokenServiceImpl;
 import com.dialog.user.domain.ForgotPasswordRequestDTO;
+import com.dialog.user.domain.Job;
 import com.dialog.user.domain.LoginDto;
 import com.dialog.user.domain.MeetUser;
 import com.dialog.user.domain.MeetUserDto;
@@ -86,7 +87,7 @@ public class MeetUserController {
         // Refresh Token 생성 및 반환할 DTO 생성
         RefreshTokenDto refreshTokenDto = refreshTokenService.createRefreshTokenDto(user);
 
-        // 2. HTTP 응답 설정 (CookieUtill 클래스에서 쿠키 처리)
+        // HTTP 응답 설정 (CookieUtill 클래스에서 쿠키 처리)
         response.addCookie(cookieUtil.createAccessTokenCookie(accessToken));
         response.addCookie(cookieUtil.createRefreshTokenCookie(refreshTokenDto.getRefreshToken()));
 
@@ -97,12 +98,15 @@ public class MeetUserController {
         	// 아이디 기억하기는 js 에서 접근해도 위험이 적어 HttpOnly=false 로 설정해줌
             response.addCookie(cookieUtil.deleteCookie("savedEmail", false));
         }
-
+        // 직무가 None 인지 확인
+        boolean needJobSetup = (user.getJob() == Job.NONE);
+        
         // 로그인 성공 정보와 토큰, 사용자 정보 등을 JSON 응답의 형태로 반환
         return ResponseEntity.ok(Map.of(
             "success", true,
             "message", "로그인 성공",
             "refreshTokenExpiresAt", refreshTokenDto.getExpiresAt(),
+            "needJobSetup", needJobSetup,
             "user", Map.of(
                 "name", user.getName(),
                 "email", user.getEmail(),

--- a/src/main/java/com/dialog/user/domain/LoginDto.java
+++ b/src/main/java/com/dialog/user/domain/LoginDto.java
@@ -21,4 +21,7 @@ public class LoginDto {
     // 아이디 기억하기 체크 여부 추가
     private boolean rememberId; 
     
+    // 직무 설정 여부 확인 
+    private boolean needJobSetup;
+    
 }

--- a/src/main/java/com/dialog/user/service/CustomUserDetails.java
+++ b/src/main/java/com/dialog/user/service/CustomUserDetails.java
@@ -7,6 +7,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import com.dialog.user.domain.Job;
 import com.dialog.user.domain.MeetUser;
 
 public class CustomUserDetails implements UserDetails {
@@ -19,6 +20,11 @@ public class CustomUserDetails implements UserDetails {
     
     public MeetUser getMeetUser() {
         return this.user;
+    }
+    
+    // 직무 설정이 안 되어 있는지 확인
+    public boolean isJobEmpty() {
+        return this.user.getJob() == Job.NONE; 
     }
 
     public Long getId() {


### PR DESCRIPTION
## **구현 기능 요약**
* 사용자 로그인 시 직무설정 안한 사용자인 경우 직무 설정 시 챗봇 사용 경험 향상 안내 모달 추가

---

## **개발 내역 상세**
* LoginDto 직무 설정 유무 확인 변수 추가
* 컨트롤러 로그인 메서드 내부 직무 설정 여부 확인 로직 추가
* 로그인 성공 핸들러 내부 직무 설정 여부 확인 하여 미 설정 시 targetUrl 리다이렉트 발생
* targetUrl 발생 시 모달창 나올수 있도록 로직 추가
* CustomOAuth2User 내부 Job 컬럼 비어있는지 확인 메서드 추가 (소셜 로그인 사용자)
* CustomUserDetails 내부 Job 컬럼 비어있는지 확인 메서드 추가 (일반 로그인 사용자)

---

## **검증 방법**
1.  직무 설정 안한 사용자 아이디로 로그인
2. 로그인 시 직무설정 알림 모달창 뜨는지 확인 (소셜 로그인, 일반 로그인 둘다 확인)

---

## **추가 개선 / TODO**
* 다음 작업: 스타일 변경 여부 확인
