### PR TITLE
feat: [BE] 캘린더 페이지 할일 삭제 시 삭제 후 회의로 생성되는 오류 해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -306,7 +306,7 @@ design-assets/
 *personal*
 *private*
 *confidential*
-
+DockerFile
 # ===============================================
 # OAuth2 인증 로직 핵심 소스 코드 예외 처리
 # 민감 정보 패턴(*auth*)에 걸리지만, 필수 소스 코드이므로 강제 포함

--- a/src/main/java/com/dialog/calendarevent/domain/CalendarEventResponse.java
+++ b/src/main/java/com/dialog/calendarevent/domain/CalendarEventResponse.java
@@ -36,6 +36,8 @@ public class CalendarEventResponse {
 	private String sourceId;
 	private String googleEventId;
 	private LocalDateTime createdAt;
+	
+	private String status;
 
 	public static CalendarEventResponse from(CalendarEvent entity) {
 		if (entity == null) {

--- a/src/main/java/com/dialog/calendarevent/service/GoogleCalendarApiClient.java
+++ b/src/main/java/com/dialog/calendarevent/service/GoogleCalendarApiClient.java
@@ -150,9 +150,18 @@ public class GoogleCalendarApiClient {
 					.parse(googleEvent.getStart().getDateTime().toString(), DateTimeFormatter.ISO_DATE_TIME).toString();
 		}
 
-		return CalendarEventResponse.builder().id(null) // Google 이벤트는 우리 DB ID가 없음
-				.userId(null).title(googleEvent.getSummary()).eventDate(eventDateStr).time(null).eventType("MEETING")
-				.isImportant(false).sourceId(googleEvent.getId()).googleEventId(googleEvent.getId()).createdAt(null)
+		return CalendarEventResponse.builder()
+				.id(null) // Google 이벤트는 우리 DB ID가 없음
+				.userId(null)
+				.title(googleEvent.getSummary())
+				.eventDate(eventDateStr)
+				.time(null)
+				.eventType("MEETING")
+				.isImportant(false)
+				.sourceId(googleEvent.getId())
+				.googleEventId(googleEvent.getId())
+				.createdAt(null)
+				.status(googleEvent.getStatus())
 				.build();
 	}
 
@@ -228,9 +237,9 @@ public class GoogleCalendarApiClient {
 		//final String GOOGLE_EVENT_DELETE_URL = GOOGLE_CALENDAR_URL + "/{eventId}";
 		String deleteUrl = this.googleCalendarUrl + "/{eventId}";
 		try {
-			webClient.delete() // 2. [핵심] .delete() 메서드 사용
-					.uri(this.googleCalendarUrl, calendarId, eventId) // 3. URL 변수 매핑
-					.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken) // 4. 헤더 설정
+			webClient.delete() // delete() 메서드 사용
+					.uri(deleteUrl, calendarId, eventId) // URL 변수 매핑
+					.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken) // 헤더 설정
 					.retrieve().onStatus(HttpStatusCode::isError, response -> {
 						log.error("Google Calendar 이벤트 삭제(Delete) 실패. Status: {}", response.statusCode());
 
@@ -245,7 +254,7 @@ public class GoogleCalendarApiClient {
 
 		} catch (Exception e) {
 			log.error("Google API 통신 중 일정 삭제(Delete) 예외 발생", e);
-			throw new GoogleOAuthException("일정 삭제(Delete) API 통신 실패");
+			throw new RuntimeException(e.getMessage(), e);
 		}
 	}
 }


### PR DESCRIPTION
## **구현 기능 요약**
* 캘린더 페이지 내부 할일 삭제 시 삭제 후 할일이 회의로 생성되는 오류 해결

---

## **개발 내역 상세**
* CalendarEventResponse 내부 status 변수 추가
* CalendarEventService 내부 캘린더 조회 시 로컬 데이터 조회 및 구글 캘린더 이벤트 병합 및 필터링 추가
* CalendarEventService 내부 캘린더 이벤트 삭제 메서드 내부 구글 API 요청 로직 수정
* GoogleCalendarApiClient 내부 convertToCalendarEventDTO 으로 변환 해주는 메서드 내부 구글 이벤트 status 가져오는 로직 추가
---

## **검증 방법**
1. 구글 캘린더 페이지 내부 할일 추가
2. 추가된 할일 삭제
3. 할일 삭제 시 회의로 추가 안되는지 확인

---

## **추가 개선 / TODO**
