### PR TITLE
feat: [BE] 할일 삭제, 관리자 페이지 회의 삭제 오류 수정 및 구글 캘린더 연동 오류 수정

### DIFF
--- a/src/main/java/com/dialog/calendarevent/repository/CalendarEventRepository.java
+++ b/src/main/java/com/dialog/calendarevent/repository/CalendarEventRepository.java
@@ -15,4 +15,6 @@ public interface CalendarEventRepository extends JpaRepository<CalendarEvent, Lo
 	List<CalendarEvent> findByUserIdAndEventDateBetween(Long userId, LocalDate startDate, LocalDate endDate);
 
 	Optional<CalendarEvent> findByGoogleEventIdAndUserId(String eventId, Long id);
+
+	void deleteByMeetingId(Long meetingId);
 }

--- a/src/main/java/com/dialog/googleauth/controller/GoogleAuthController.java
+++ b/src/main/java/com/dialog/googleauth/controller/GoogleAuthController.java
@@ -41,7 +41,8 @@ public class GoogleAuthController {
         } catch (UserNotFoundException e) {
             return ResponseEntity.status(404).body(Map.of("error", e.getMessage()));
         } catch (Exception e) {
-            return ResponseEntity.status(500).body(Map.of("error", "내부 서버 오류"));
+        	e.printStackTrace(); 
+            return ResponseEntity.status(500).body(Map.of("error", "서버 오류: " + e.getMessage()));
         }
     }
 

--- a/src/main/java/com/dialog/user/service/AdminService.java
+++ b/src/main/java/com/dialog/user/service/AdminService.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.List;
 
+import com.dialog.calendarevent.repository.CalendarEventRepository;
 import com.dialog.exception.ResourceNotFoundException;
 import com.dialog.exception.UserNotFoundException;
 import com.dialog.meeting.repository.MeetingRepository;
@@ -30,6 +31,7 @@ public class AdminService {
 	private final ParticipantRepository participantRepository;
 	private final MeetingRepository meetingRepository;
 	private final RefreshTokenRepository refreshTokenRepository;
+	private final CalendarEventRepository calendarEventRepository;
 	
 	@Transactional(readOnly = true)
 	public List<AdminResponse> getAllUsers() {
@@ -136,6 +138,7 @@ public class AdminService {
 	    }
 	  
     	participantRepository.deleteByMeetingId(meetingId); 
+    	calendarEventRepository.deleteByMeetingId(meetingId);
     	meetingRepository.deleteById(meetingId);
 	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,8 @@ spring:
   thymeleaf:
     cache: false
 
+  # Spring Security OAuth2 설정 (로그인용)
+  # client-id와 secret은 도커 환경변수(SPRING_SECURITY_OAUTH2_...)에서 자동으로 주입됩니다.
   security:
     oauth2:
       client:
@@ -49,9 +51,14 @@ logging:
   level:
     com.dialog.security.jwt: DEBUG
     com.dialog.security.oauth2: DEBUG
-# OAuth2 리다이렉트 URI 설정
-#app:
-  #oauth2:
-    #fail-uri: http://localhost:8080/login?error=true
-    #success-uri: http://localhost:8080/dashboard
-    #redirect-uri: http://localhost:8080/oauth2/redirect
+# 커스텀 구글 API 설정 (캘린더 연동용)
+google:
+  client:
+    id: ${GOOGLE_CLIENT_ID}          # docker-compose의 GOOGLE_CLIENT_ID 매핑
+    secret: ${GOOGLE_CLIENT_SECRET}  # docker-compose의 GOOGLE_CLIENT_SECRET 매핑
+  redirect:
+    uri: ${GOOGLE_REDIRECT_URI}      # docker-compose의 GOOGLE_REDIRECT_URI 매핑
+  api:
+    calendar-url: ${GOOGLE_API_CALENDAR_URL} # docker-compose의 GOOGLE_API_CALENDAR_URL 매핑
+app:
+  frontend-url: ${APP_FRONTEND_URL}  # docker-compose의 APP_FRONTEND_URL 매핑


### PR DESCRIPTION
## **구현 기능 요약**
* 할일 삭제 버튼 클릭 시 DB 에서 삭제 안되는 문제 해결
* 관리자 페이지 -> 회의 관리 페이지 내부 회의 삭제 버튼 클릭 시 삭제 안되는 문제 해결
* 일반 로그인, 카카오 로그인 사용자 구글 캘린더 연동 버튼 클릭 시 연동 안되는 문제 해결

---

## **개발 내역 상세**
* 할일 삭제 로직 부분 에서 FK 참조 로직 순서 변경 및 추가
* 회의 삭제 로직 부분 에서 FK 참조 로직 순서 변경 및 추가
* 캘린더 연동 서비스단 및 컨트롤러 수정 (GoogleAuthController , GoogleAuthService) 내부 메서드 수정
* GoogleAuthService 내부 Value 어노테이션 사용하여 application.yml 매핑 잘되도록 추가
* application.yml 구글 캘린더 서비스 url  추가

---

## **검증 방법**
1.  캘린더 페이지 내부 할일 생성 후 삭제한뒤 DB 확인
2.  관리자 페이지 -> 회의 관리 페이지 -> 회의 삭제
3.  일반, 카카오 로그인 후 구글 캘린더 버튼 클릭후 캘린더 연동 여부 확인

---

## **추가 개선 / TODO**