### PR TITLE
feat: [BE] 메인 페이지 개인별 통계 API 구현 및 UI 연동

### DIFF
--- a/src/main/java/com/dialog/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/dialog/meeting/repository/MeetingRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.dialog.meeting.domain.Meeting;
+import com.dialog.meeting.domain.Status;
 import com.dialog.user.domain.MeetUser;
 
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
@@ -29,7 +30,17 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
 	// 어제 생성한 회의 수
 	@Query(value = "SELECT COUNT(*) FROM meeting WHERE created_at BETWEEN :start AND :end", nativeQuery = true)
 	long countYesterdayCreatedMeetings(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
-
+	
+	// 어드민 페이지 내부 현재 등록된 모든 회의 개수 조회
 	List<Meeting> findAllByScheduledAtBetween(LocalDateTime startDateTime, LocalDateTime endDateTime);	
+	
+	// 특정 유저의 기간 내 모든 회의 리스트 조회 (총 참여 시간 계산용)
+	List<Meeting> findAllByHostUserAndScheduledAtBetween(MeetUser hostUser, LocalDateTime start, LocalDateTime end);
+
+	// 특정 유저의 기간 내 회의 개수 조회 (이번 달 회의 카드용)
+	long countByHostUserAndScheduledAtBetween(MeetUser hostUser, LocalDateTime start, LocalDateTime end);
+
+	// 특정 유저의 기간 내 특정 상태(예: COMPLETED)인 회의 개수 조회 
+	long countByHostUserAndStatusAndScheduledAtBetween(MeetUser hostUser, Status status, LocalDateTime start, LocalDateTime end);
 	
 }

--- a/src/main/java/com/dialog/todo/repository/TodoRepository.java
+++ b/src/main/java/com/dialog/todo/repository/TodoRepository.java
@@ -1,8 +1,17 @@
 package com.dialog.todo.repository;
+import java.time.LocalDateTime;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.dialog.todo.domain.Todo;
+import com.dialog.todo.domain.TodoStatus;
+import com.dialog.user.domain.MeetUser;
 
 public interface TodoRepository extends JpaRepository<Todo, Long> {
 
+	// 미결 아이템 총 개수 (상태가 COMPLETED가 아닌 것)
+    long countByUserAndStatusNot(MeetUser user, TodoStatus status);
+
+  // 특정 기간에 생성된 미결 아이템 개수
+  long countByUserAndStatusNotAndCreatedAtBetween(MeetUser user, TodoStatus status, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/dialog/user/controller/MeetUserController.java
+++ b/src/main/java/com/dialog/user/controller/MeetUserController.java
@@ -11,6 +11,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
@@ -31,6 +32,7 @@ import com.dialog.security.oauth2.SocialUserInfoFactory;
 import com.dialog.token.domain.RefreshTokenDto;
 import com.dialog.token.service.RefreshTokenServiceImpl;
 import com.dialog.user.domain.ForgotPasswordRequestDTO;
+import com.dialog.user.domain.HomeStatsDto;
 import com.dialog.user.domain.Job;
 import com.dialog.user.domain.LoginDto;
 import com.dialog.user.domain.MeetUser;
@@ -38,6 +40,7 @@ import com.dialog.user.domain.MeetUserDto;
 import com.dialog.user.domain.ResetPasswordRequestDTO;
 import com.dialog.user.domain.UserApiResponseDTO;
 import com.dialog.user.domain.UserSettingsUpdateDto;
+import com.dialog.user.service.CustomUserDetails;
 import com.dialog.user.service.MeetuserService;
 
 import jakarta.servlet.http.Cookie;
@@ -171,5 +174,17 @@ public class MeetUserController {
     public ResponseEntity<UserApiResponseDTO> resetPassword(@Valid @RequestBody ResetPasswordRequestDTO request) {
         meetuserService.resetPassword(request.getToken(), request.getNewPassword());
         return ResponseEntity.ok(new UserApiResponseDTO(true, "비밀번호가 성공적으로 변경되었습니다."));
+    }
+    
+    @GetMapping("api/home/stats")
+    public ResponseEntity<HomeStatsDto> getHomeStats(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        // 로그인 체크
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        
+        // 서비스 호출 및 응답
+        HomeStatsDto stats = meetuserService.getHomeStats(userDetails.getId());
+        return ResponseEntity.ok(stats);
     }
 }

--- a/src/main/java/com/dialog/user/domain/HomeStatsDto.java
+++ b/src/main/java/com/dialog/user/domain/HomeStatsDto.java
@@ -1,0 +1,32 @@
+package com.dialog.user.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class HomeStatsDto {
+    // 이번 달 회의
+    private long thisMonthMeetingCount;
+    // 예: "+12%" 또는 "-2"
+    private String meetingCountDiff; 
+
+    // 총 참여 시간 (시간 단위)
+    private String totalMeetingTime;
+    private String meetingHoursDiff;
+
+    // 미결 액션아이템 (Todo 중 완료되지 않은 것)
+    private long openActionItems;
+    // 전월 대비 혹은 어제 대비
+    private String actionItemsDiff;
+
+    // 종료된 회의 수
+    private long confirmedMeetings;
+    private String meetingsDiff;
+}

--- a/src/main/java/com/dialog/user/service/MeetuserService.java
+++ b/src/main/java/com/dialog/user/service/MeetuserService.java
@@ -1,6 +1,11 @@
 package com.dialog.user.service;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
+import com.dialog.todo.domain.TodoStatus;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -21,8 +26,13 @@ import com.dialog.exception.TermsNotAcceptedException;
 import com.dialog.exception.UserAlreadyExistsException;
 import com.dialog.exception.UserNotFoundException;
 import com.dialog.exception.UserRoleAccessDeniedException;
+import com.dialog.meeting.domain.Meeting;
+import com.dialog.meeting.domain.Status;
+import com.dialog.meeting.repository.MeetingRepository;
 import com.dialog.security.oauth2.SocialUserInfo;
 import com.dialog.security.oauth2.SocialUserInfoFactory;
+import com.dialog.todo.repository.TodoRepository;
+import com.dialog.user.domain.HomeStatsDto;
 import com.dialog.user.domain.MeetUser;
 import com.dialog.user.domain.MeetUserDto;
 import com.dialog.user.domain.Role;
@@ -36,6 +46,8 @@ import lombok.RequiredArgsConstructor;
 public class MeetuserService {
 
     private final MeetUserRepository meetUserRepository; 
+    private final MeetingRepository meetingRepository;
+    private final TodoRepository todoRepository;
     private final PasswordEncoder passwordEncoder;       
     private final EmailService emailService;
 
@@ -176,4 +188,110 @@ public class MeetuserService {
         meetUserRepository.save(user);
     }
     
+    // 홈화면 상태 카드 4개 데이터 조회
+    public HomeStatsDto getHomeStats(Long userId) {
+        MeetUser user = meetUserRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자 없음"));
+
+        // 날짜 기준 설정 (이번 달 vs 지난 달)
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime startOfThisMonth = now.with(TemporalAdjusters.firstDayOfMonth()).with(LocalTime.MIN);
+        LocalDateTime endOfThisMonth = now.with(TemporalAdjusters.lastDayOfMonth()).with(LocalTime.MAX);
+        
+        LocalDateTime startOfLastMonth = startOfThisMonth.minusMonths(1);
+        LocalDateTime endOfLastMonth = endOfThisMonth.minusMonths(1);
+
+
+        // 이번 달 회의 (전체 생성 건수)
+        long thisMonthCount = meetingRepository.countByHostUserAndScheduledAtBetween(user, startOfThisMonth, endOfThisMonth);
+        long lastMonthCount = meetingRepository.countByHostUserAndScheduledAtBetween(user, startOfLastMonth, endOfLastMonth);
+        String meetingDiff = calculateDiffPercentage(thisMonthCount, lastMonthCount); // 예: "+12%"
+
+        // 총 참여 시간 (실제 수행 시간 합계)
+        long thisMonthSeconds = calculateTotalDuration(user, startOfThisMonth, endOfThisMonth);
+        long lastMonthSeconds = calculateTotalDuration(user, startOfLastMonth, endOfLastMonth);
+        
+        // 초 단위를 "1h 30m" 형식의 문자열로 변환
+        String formattedTime = formatDuration(thisMonthSeconds); 
+        String durationDiff = calculateDiffPercentage(thisMonthSeconds, lastMonthSeconds); // 예: "+8%"
+
+        // 미결 액션아이템 (현재 상태가 COMPLETED가 아닌 것 전체)
+        long openTodos = todoRepository.countByUserAndStatusNot(user, TodoStatus.COMPLETED);
+        
+        // (비교용) 이번달 생성된 Todo vs 지난달 생성된 Todo 비교 
+        long thisMonthCreated = todoRepository.countByUserAndStatusNotAndCreatedAtBetween(
+                user, TodoStatus.COMPLETED, startOfThisMonth, endOfThisMonth);
+        long lastMonthCreated = todoRepository.countByUserAndStatusNotAndCreatedAtBetween(
+                user, TodoStatus.COMPLETED, startOfLastMonth, endOfLastMonth);
+        
+        String actionDiff = formatCountDiff(thisMonthCreated - lastMonthCreated);
+
+        // 종료된 회의 (확정된 주요결정사항 대용)
+        long completedThisMonth = meetingRepository.countByHostUserAndStatusAndScheduledAtBetween(user, Status.COMPLETED, startOfThisMonth, endOfThisMonth);
+        long completedLastMonth = meetingRepository.countByHostUserAndStatusAndScheduledAtBetween(user, Status.COMPLETED, startOfLastMonth, endOfLastMonth);
+        String meetingsDiff = calculateDiffPercentage(completedThisMonth, completedLastMonth); // 예: "+5%"
+
+        // DTO 빌드 및 반환
+        return HomeStatsDto.builder()
+                .thisMonthMeetingCount(thisMonthCount)
+                .meetingCountDiff(meetingDiff)
+                
+                .totalMeetingTime(formattedTime)
+                .meetingHoursDiff(durationDiff)
+                
+                .openActionItems(openTodos)
+                .actionItemsDiff(actionDiff)
+                
+                .confirmedMeetings(completedThisMonth)
+                .meetingsDiff(meetingsDiff)
+                .build();
+    }
+
+    // 기간 내 회의 시간 합계 계산
+    private long calculateTotalDuration(MeetUser user, LocalDateTime start, LocalDateTime end) {
+        List<Meeting> meetings = meetingRepository.findAllByHostUserAndScheduledAtBetween(user, start, end);
+        long totalSeconds = 0;
+        
+        for (Meeting m : meetings) {
+            // 실제 회의 기록(시작/종료 시간)이 있는 경우에만 계산
+            if (m.getStartedAt() != null && m.getEndedAt() != null) {
+                long duration = Duration.between(m.getStartedAt(), m.getEndedAt()).getSeconds();
+                totalSeconds += duration;
+            }
+        }
+        return totalSeconds;
+    }
+
+    // 퍼센트 차이 계산
+    private String calculateDiffPercentage(long current, long previous) {
+        if (previous == 0) {
+            return current > 0 ? "+100%" : "0%";
+        }
+        double diff = ((double) (current - previous) / previous) * 100;
+        return (diff >= 0 ? "+" : "") + String.format("%.0f", diff) + "%";
+    }
+    
+    // 단순 개수 차이 포맷팅 ("+2개", "-1개")
+    private String formatCountDiff(long diff) {
+        return (diff >= 0 ? "+" : "") + diff + "개";
+    }
+    // 초를 "1h 30m" 형식으로 바꾸는 헬퍼 메서드
+    private String formatDuration(long totalSeconds) {
+        if (totalSeconds == 0) {
+            return "0m"; // 0초면 0m로 표시
+        }
+        
+        long hours = totalSeconds / 3600;
+        long minutes = (totalSeconds % 3600) / 60;
+
+        if (hours > 0) {
+            // 1시간 이상일 때: "1h 30m" (분이 0이면 "1h")
+            return minutes > 0 ? String.format("%dh %dm", hours, minutes) : String.format("%dh", hours);
+        } else {
+            // 1시간 미만일 때: "45m"
+            return String.format("%dm", minutes);
+        }
+    }
 }
+
+    


### PR DESCRIPTION
## **구현 기능 요약**
* 메인 홈 화면(home.html) 하단에 위치한 4가지 핵심 지표(이번 달 회의, 총 참여 시간, 미결 액션아이템, 종료된 회의)를 하드코딩된 데이터  에서 사용자 실데이터 기반의 동적 통계로 전환

* 개인별 통계 제공: 로그인한 사용자의 데이터를 기반으로 월별 활동량을 집계합니다.

* 증감률 시각화: 지난달 대비 활동량 변화를 퍼센트(%) 또는 개수(건)로 계산하여 UI에 반영했습니다.

* 데이터 로딩 최적화: 페이지 초기화 시점의 비동기 처리 순서를 재정비하여 데이터 누락 문제를 해결했습니다.

---

## **개발 내역 상세**
* 통계 비즈니스 로직 구현 (HomeService)
* 기간별 집계: LocalDateTime을 활용하여 '이번 달'과 '지난 달'의 범위를 계산, 해당 기간 내의 회의 및 할 일 데이터를 카운트 함
* 시간 포맷팅: 초(Second) 단위로 계산된 총 회의 시간을 사용자 친화적인 문자열 포맷(1h 30m, 45m)으로 변환하는 로직을 추가
* 증감률 계산: 전월 대비 데이터 변화량을 계산, 0건일 경우의 예외 처리(100% 등) 로직 적용
* MeetingRepository: 특정 기간 내 사용자가 주최한 회의 수 및 완료된 회의 수를 조회하는 메서드 추가.
* TodoRepository: 미완료(Open) 상태인 액션 아이템과 기간별 생성 건수를 조회하는 메서드 추가.
* API 엔드포인트: /api/home/stats GET 요청을 처리하는 HomeController 구현.
---

## **검증 방법**
1. 데이터 정합성 확인:
     * 로그인 후 홈 화면 하단 카드의 숫자가 DB 데이터(이번 달 생성한 회의 수, 미완료 할 일 수)와 일치하는지 확인
2.시간 포맷 확인:
     * 회의 시간이 1시간 미만일 때(XXm)와 1시간 이상일 때(Xh YYm) 형식이 올바르게 표시되는지 확인
3. 초기 로딩 테스트:
     * 브라우저 강력 새로고침(Ctrl+F5) 시에도 데이터가 누락되지 않고 즉시 표시되는지 확인
4. 증감률 표시:
     * 데이터가 없는 경우(0건)와 있는 경우에 대해 퍼센트 표기가 정상적으로 계산되는지 확인

---

## **추가 개선 / TODO**
