### PR TITLE
feat: [BE] FastAPI 챗봇 API 프록시 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -306,7 +306,7 @@ design-assets/
 *personal*
 *private*
 *confidential*
-DockerFile
+
 # ===============================================
 # OAuth2 인증 로직 핵심 소스 코드 예외 처리
 # 민감 정보 패턴(*auth*)에 걸리지만, 필수 소스 코드이므로 강제 포함

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# ================================
+# 1) Build Stage (Gradle로 JAR 빌드)
+# ================================
+FROM gradle:8.5-jdk17 AS builder
+WORKDIR /app
+
+# 프로젝트 전체 복사
+COPY . .
+
+# dependency 캐싱 + build
+RUN gradle clean build -x test
+
+
+# ================================
+# 2) Run Stage (최종 JAR 실행)
+# ================================
+FROM eclipse-temurin:17-jdk
+WORKDIR /app
+
+# builder에서 생성된 jar 파일 복사
+COPY --from=builder /app/build/libs/*.jar app.jar
+
+# 8080 포트 오픈
+EXPOSE 8080
+
+# Spring Boot 실행
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/src/main/java/com/dialog/DialogBackendApplication.java
+++ b/src/main/java/com/dialog/DialogBackendApplication.java
@@ -2,14 +2,18 @@ package com.dialog;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 import com.dialog.googleauth.domain.GoogleAuthDTO;
 
 @SpringBootApplication
 @EnableConfigurationProperties(GoogleAuthDTO.class)
 @ComponentScan(basePackages = {"com.dialog", "com.dialog.exception"})
+@EntityScan(basePackages = "com.dialog")
+@EnableJpaRepositories(basePackages = "com.dialog")
 public class DialogBackendApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/dialog/calendarevent/controller/CalendarEventController.java
+++ b/src/main/java/com/dialog/calendarevent/controller/CalendarEventController.java
@@ -111,7 +111,8 @@ public class CalendarEventController {
 		return ResponseEntity.ok().build();
 	}
 
-	@PatchMapping("/calendar/{eventId}/importance")
+	// @PatchMapping("/calendar/{eventId}/importance")
+	@PatchMapping("/calendar/events/{eventId}/importance")
 	public ResponseEntity<Void> toggleImportance(@PathVariable("eventId") String eventId, Principal principal) {
 
 		if (principal == null) {

--- a/src/main/java/com/dialog/chatbot/ChatbotController.java
+++ b/src/main/java/com/dialog/chatbot/ChatbotController.java
@@ -36,7 +36,7 @@ public class ChatbotController {
     
     // 회의록 검색 챗봇 (Python으로 전달)
     @PostMapping("/search")
-    public ResponseEntity<String> searchChat(  // [수정] Map → String
+    public ResponseEntity<String> searchChat(
             @RequestBody Map<String, Object> request,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         
@@ -90,7 +90,7 @@ public class ChatbotController {
     
     // FAQ 챗봇 (Python으로 전달)
     @PostMapping("/faq")
-    public ResponseEntity<String> faqChat(  // [수정] Map → String
+    public ResponseEntity<String> faqChat(
             @RequestBody Map<String, Object> request,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: true
     properties:
       hibernate:
@@ -51,6 +51,16 @@ logging:
   level:
     com.dialog.security.jwt: DEBUG
     com.dialog.security.oauth2: DEBUG
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+    
+# OAuth2 리다이렉트 URI 설정
+#app:
+  #oauth2:
+    #fail-uri: http://localhost:8080/login?error=true
+    #success-uri: http://localhost:8080/dashboard
+    #redirect-uri: http://localhost:8080/oauth2/redirect
+    
 # 커스텀 구글 API 설정 (캘린더 연동용)
 google:
   client:


### PR DESCRIPTION
## **구현 기능 요약**
Spring Boot에서 FastAPI 챗봇 서비스 연동 및 사용자 인증 정보 전달

---

## **개발 내역 상세**

### **챗봇 통합**
* **`ChatbotController.java`**: FastAPI 챗봇 프록시 API 구현 (/api/chatbot/search)
* **`AppConfig.java`**: RestTemplate Bean 설정
* **`CustomUserDetails.java`**: getMeetUser() 메서드 추가 (user 정보 전달)

### **설정**
* **`application.yml`**: FastAPI URL 환경변수 설정 (FASTAPI_URL)

---

## **검증 방법**

```bash
# 서버 실행
./gradlew bootRun

# 챗봇 API 테스트
POST http://localhost:8080/api/chatbot/search
Headers: Authorization: Bearer {JWT_TOKEN}
{
  "message": "회의 있었어?",
  "user_job": "BACKEND_DEVELOPER"
}

# 응답 확인
{
  "answer": "네, 회의로는 다음과 같은 것들이 있어요! ...",
  "source": "multiple_meetings",
  "session_id": "abc123"
}
```