### PR TITLE
release: [BE] v1.3.0 - Google 캘린더 연동 및 HTTPS/도메인 설정

### DIFF
--- a/src/main/java/com/dialog/config/WebConfig.java
+++ b/src/main/java/com/dialog/config/WebConfig.java
@@ -12,9 +12,11 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedOrigins(
                         "http://localhost:5500",      // 로컬 테스트용
                         "http://127.0.0.1:5500",      // 로컬 테스트용
-                        "http://dialogai.duckdns.org",      // 배포된 프론트엔드 도메인 (HTTP)
-                        "https://dialogai.duckdns.org",     // 혹시 HTTPS를 쓴다면 필수
-                        "http://dialogai.duckdns.org:5500"  // 만약 배포 후에도 5500 포트를 쓴다면
+                        // "http://dialogai.duckdns.org",      // 배포된 프론트엔드 도메인 (HTTP)
+                        // "https://dialogai.duckdns.org",     // 혹시 HTTPS를 쓴다면 필수
+                        // "http://dialogai.duckdns.org:5500"  // 만약 배포 후에도 5500 포트를 쓴다면
+                        "http://dialogai.ddns.net",
+                        "https://dialogai.ddns.net"
                 )
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS") // "*" 대신 명시하는 것이 보안상 좋음
                 .allowedHeaders("*")

--- a/src/main/java/com/dialog/googleauth/controller/GoogleAuthController.java
+++ b/src/main/java/com/dialog/googleauth/controller/GoogleAuthController.java
@@ -29,13 +29,24 @@ public class GoogleAuthController {
     
     @GetMapping("/api/calendar/link/start")
     public ResponseEntity<?> startGoogleAccountLink(Authentication authentication) {
-        if (authentication == null || !(authentication.getPrincipal() instanceof UserDetails)) {
+        // [수정] Principal이 null인지만 체크 (UserDetails 타입 강제 제거 - JWT 인증 시 String 타입일 수 있음)
+        if (authentication == null || authentication.getPrincipal() == null) {
             return ResponseEntity.status(401).body(Map.of("error", "인증이 필요합니다."));
         }
 
         try {
-            UserDetails userDetails = (UserDetails) authentication.getPrincipal();
-            Long userId = googleAuthService.extractUserId(userDetails);
+            Object principal = authentication.getPrincipal();
+            Long userId;
+            
+            // [수정] Principal 타입에 따라 분기 처리 (일반/카카오 로그인 사용자도 Google 캘린더 연동 가능하도록)
+            if (principal instanceof UserDetails userDetails) {
+                userId = googleAuthService.extractUserId(userDetails);
+            } else if (principal instanceof String email) {
+                userId = googleAuthService.extractUserIdByEmail(email);
+            } else {
+                return ResponseEntity.status(401).body(Map.of("error", "지원하지 않는 인증 타입입니다."));
+            }
+                        
             String authUrl = googleAuthService.generateAuthUrl(userId);
             return ResponseEntity.ok(Map.of("authUrl", authUrl));
         } catch (UserNotFoundException e) {

--- a/src/main/java/com/dialog/googleauth/service/GoogleAuthService.java
+++ b/src/main/java/com/dialog/googleauth/service/GoogleAuthService.java
@@ -42,7 +42,8 @@ public class GoogleAuthService {
     @Value("${google.client.secret}")
     private String clientSecret;
 
-    @Value("${google.redirect.uri}")
+    // [수정] 캘린더 연동용 별도 redirect URI 사용
+    @Value("${google.calendar.link.redirect.uri}")
     private String redirectUri;
 
     private static final String SCOPE = "https://www.googleapis.com/auth/calendar.events";
@@ -129,5 +130,15 @@ public String generateAuthUrl(Long userId) {
             log.error("구글 토큰 교환 실패", e);
             throw new GoogleTokenExchangeException("Google 토큰 통신 오류: " + e.getMessage(), e);
         }
+    }
+
+    // [수정] JWT 인증 시 Principal이 String(email)인 경우를 위한 메서드 추가
+    public Long extractUserIdByEmail(String email) {
+        if (email == null || email.isBlank()) {
+            throw new IllegalArgumentException("이메일이 비어있습니다.");
+        }
+        MeetUser user = meetUserRepository.findByEmail(email)
+                .orElseThrow(() -> new UserNotFoundException("DB에서 사용자를 찾을 수 없습니다: " + email));
+        return user.getId();
     }
 }

--- a/src/main/java/com/dialog/security/SecurityConfig.java
+++ b/src/main/java/com/dialog/security/SecurityConfig.java
@@ -23,6 +23,11 @@ import com.dialog.user.service.CustomOAuth2UserService;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import java.util.Arrays;
+import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -122,5 +127,29 @@ public class SecurityConfig {
             )
             
             .build();
+    }
+
+    // [수정] CORS 설정 Bean 추가 - .cors(withDefaults())가 제대로 동작하도록
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        // [수정] WebConfig.java와 origin 목록 통일 - HTTP/HTTPS 둘 다 허용
+        configuration.setAllowedOrigins(Arrays.asList(
+            "http://localhost:5500",
+            "http://127.0.0.1:5500",
+            // "http://dialogai.duckdns.org",
+            // "https://dialogai.duckdns.org",
+            // "http://dialogai.duckdns.org:5500"
+            "http://dialogai.ddns.net",
+            "https://dialogai.ddns.net"
+        ));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
+        configuration.setAllowedHeaders(Arrays.asList("*"));
+        configuration.setAllowCredentials(true);
+        configuration.setMaxAge(3600L);
+        
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,6 @@
 server:
   port: 8080
+  forward-headers-strategy: framework
 
 spring:
   profiles:
@@ -14,17 +15,26 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.MySQL8Dialect
 
+  mail:
+    host: ${SPRING_MAIL_HOST:smtp.gmail.com}
+    port: ${SPRING_MAIL_PORT:587}
+    username: ${SPRING_MAIL_USERNAME}
+    password: ${SPRING_MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
   thymeleaf:
     cache: false
 
-  # Spring Security OAuth2 설정 (로그인용)
-  # client-id와 secret은 도커 환경변수(SPRING_SECURITY_OAUTH2_...)에서 자동으로 주입됩니다.
   security:
     oauth2:
       client:
         registration:
           google:
-            # 배포 환경 도메인 적용
             client-id: ${SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_GOOGLE_CLIENT_ID}
             client-secret: ${SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_GOOGLE_CLIENT_SECRET}
             redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
@@ -59,24 +69,29 @@ logging:
     com.dialog.security.oauth2: DEBUG
     org.hibernate.SQL: DEBUG
     org.hibernate.type.descriptor.sql.BasicBinder: TRACE
-    
-# OAuth2 리다이렉트 URI 설정
+
+# [병합] 두 버전 통합 - 환경변수 기반 설정
 app:
+  auth:
+    cookie-domain: ${COOKIE_DOMAIN:}
   oauth2:
-    fail-uri: ${APP_OAUTH2_FAIL_URI:http://localhost:8080/login?error=true}
     redirect-uri: ${APP_OAUTH2_REDIRECT_URI:http://localhost:8080/home}
+    fail-uri: ${APP_OAUTH2_FAIL_URI:http://localhost:8080/login?error=true}
   frontend-url: ${APP_FRONTEND_URL:http://localhost:8080}
 
-# 쿠키 도메인 설정 (로컬에선 비워둠, 배포에선 도메인 설정)
+# [병합] 쿠키 도메인 (하위 호환)
 cookie:
   domain: ${COOKIE_DOMAIN:}
 
-# 커스텀 구글 API 설정 (캘린더 연동용)
 google:
   client:
-    id: ${GOOGLE_CLIENT_ID}          # docker-compose의 GOOGLE_CLIENT_ID 매핑
-    secret: ${GOOGLE_CLIENT_SECRET}  # docker-compose의 GOOGLE_CLIENT_SECRET 매핑
+    id: ${GOOGLE_CLIENT_ID}
+    secret: ${GOOGLE_CLIENT_SECRET}
   redirect:
-    uri: ${GOOGLE_REDIRECT_URI}      # docker-compose의 GOOGLE_REDIRECT_URI 매핑
+    uri: ${GOOGLE_REDIRECT_URI}
   api:
-    calendar-url: ${GOOGLE_API_CALENDAR_URL} # docker-compose의 GOOGLE_API_CALENDAR_URL 매핑
+    calendar-url: ${GOOGLE_API_CALENDAR_URL}
+  calendar:
+    link:
+      redirect:
+        uri: ${GOOGLE_CALENDAR_LINK_REDIRECT_URI}


### PR DESCRIPTION
## 🚀 릴리즈 노트 v1.3.0

### 새로운 기능
- ✨ Google 캘린더 연동용 OAuth redirect URI 분리
- ✨ 캘린더 연동 콜백 엔드포인트 구현

### 버그 수정
- 🐛 Google 캘린더 연동 시 로그인 페이지로 튕기는 문제 해결
- 🐛 HTTPS 환경에서 redirect_uri가 http로 생성되는 문제 해결
- 🐛 도메인 변경 미반영 문제 해결

### 개선 사항
- ⚡ CORS 설정에 새 도메인 (dialogai.ddns.net) 추가
- ⚡ forward-headers-strategy 설정으로 리버스 프록시 환경 지원
- ⚡ SecurityConfig 캘린더 연동 엔드포인트 권한 설정

### 기술 스택
- Spring Boot 백엔드
- Google OAuth 2.0
- Caddy 리버스 프록시
- AWS EC2 운영 환경

### 배포 정보
- 배포 환경: EC2 (https://dialogai.ddns.net)
- 배포 방법: GitHub Actions CI/CD 파이프라인
- Docker 이미지: munwalk/dialog-backend:latest

### 환경변수 추가
GOOGLE_CALENDAR_LINK_REDIRECT_URI=https://dialogai.ddns.net/auth/google/link/callback